### PR TITLE
Rename `payload` to `event`

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -57,8 +57,8 @@ internal struct CodableClosureWrapper<In: Decodable, Out: Encodable>: LambdaHand
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 
@@ -72,8 +72,8 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -64,8 +64,8 @@ internal struct StringClosureWrapper: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 
@@ -79,8 +79,8 @@ internal struct StringVoidClosureWrapper: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -56,7 +56,7 @@ extension Lambda {
                 self.isGettingNextInvocation = false
                 let context = Context(logger: logger, eventLoop: self.eventLoop, invocation: invocation)
                 logger.debug("sending invocation to lambda handler \(handler)")
-                return handler.handle(context: context, payload: payload)
+                return handler.handle(context: context, event: payload)
                     .mapResult { result in
                         if case .failure(let error) = result {
                             logger.warning("lambda handler returned an error: \(error)")

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -88,7 +88,7 @@ extension Lambda {
 
     public static func test<In, Out, Handler: EventLoopLambdaHandler>(
         _ handler: Handler,
-        with payload: In,
+        with event: In,
         using config: TestConfig = .init()
     ) throws -> Out where Handler.In == In, Handler.Out == Out {
         let logger = Logger(label: "test")
@@ -105,7 +105,7 @@ extension Lambda {
                               eventLoop: eventLoop)
 
         return try eventLoop.flatSubmit {
-            handler.handle(context: context, payload: payload)
+            handler.handle(context: context, event: event)
         }.wait()
     }
 }

--- a/Sources/CodableSample/main.swift
+++ b/Sources/CodableSample/main.swift
@@ -29,9 +29,9 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = Request
     typealias Out = Response
 
-    func handle(context: Lambda.Context, payload: Request) -> EventLoopFuture<Response> {
+    func handle(context: Lambda.Context, event: Request) -> EventLoopFuture<Response> {
         // as an example, respond with the reverse the input payload
-        context.eventLoop.makeSucceededFuture(Response(body: String(payload.body.reversed())))
+        context.eventLoop.makeSucceededFuture(Response(body: String(event.body.reversed())))
     }
 }
 

--- a/Sources/StringSample/main.swift
+++ b/Sources/StringSample/main.swift
@@ -20,9 +20,9 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
+    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
         // as an example, respond with the reverse the input payload
-        context.eventLoop.makeSucceededFuture(String(payload.reversed()))
+        context.eventLoop.makeSucceededFuture(String(event.reversed()))
     }
 }
 

--- a/Tests/AWSLambdaRuntimeCoreTests/Lambda+StringTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Lambda+StringTest.swift
@@ -26,8 +26,8 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
-                callback(.success(payload))
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+                callback(.success(event))
             }
         }
 
@@ -46,7 +46,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<Void, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
                 callback(.success(()))
             }
         }
@@ -66,7 +66,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("boom")))
             }
         }
@@ -86,8 +86,8 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
-                context.eventLoop.makeSucceededFuture(payload)
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+                context.eventLoop.makeSucceededFuture(event)
             }
         }
 
@@ -106,7 +106,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<Void> {
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
             }
         }
@@ -126,7 +126,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }
@@ -189,7 +189,7 @@ class StringLambdaTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("should not be called")))
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -56,8 +56,8 @@ class LambdaTest: XCTestCase {
                 self.initialized = true
             }
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
-                callback(.success(payload))
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+                callback(.success(event))
             }
         }
 
@@ -89,7 +89,7 @@ class LambdaTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<Void, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
                 callback(.failure(TestError("should not be called")))
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -38,8 +38,8 @@ struct EchoHandler: LambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
-        callback(.success(payload))
+    func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+        callback(.success(event))
     }
 }
 
@@ -53,7 +53,7 @@ struct FailedHandler: LambdaHandler {
         self.reason = reason
     }
 
-    func handle(context: Lambda.Context, payload: String, callback: (Result<Void, Error>) -> Void) {
+    func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
         callback(.failure(TestError(self.reason)))
     }
 }

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -42,7 +42,7 @@ class CodableLambdaTest: XCTestCase {
         }
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), payload: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
         XCTAssertNil(outputBuffer)
     }
 
@@ -58,7 +58,7 @@ class CodableLambdaTest: XCTestCase {
         }
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), payload: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
         XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
         XCTAssertEqual(response?.requestId, request.requestId)
     }

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -63,9 +63,9 @@ class LambdaTestingTests: XCTestCase {
             typealias In = Request
             typealias Out = Response
 
-            func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
                 XCTAssertFalse(context.eventLoop.inEventLoop)
-                callback(.success(Response(message: "echo" + payload.name)))
+                callback(.success(Response(message: "echo" + event.name)))
             }
         }
 
@@ -80,9 +80,9 @@ class LambdaTestingTests: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
                 XCTAssertTrue(context.eventLoop.inEventLoop)
-                return context.eventLoop.makeSucceededFuture("echo" + payload)
+                return context.eventLoop.makeSucceededFuture("echo" + event)
             }
         }
 
@@ -99,7 +99,7 @@ class LambdaTestingTests: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
                 callback(.failure(MyError()))
             }
         }


### PR DESCRIPTION
### Motivation

As @Andrea-Scuderi has correctly [pointed out here](https://github.com/swift-server/swift-aws-lambda-runtime/issues/89#issuecomment-636500412), we should follow with our naming AWS closely. Currently the inputs name on all our handler protocols is `payload`, whereas AWS uses `event` in nearly all its languages:

- [Ruby](https://docs.aws.amazon.com/lambda/latest/dg/ruby-handler.html)
- [Node](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html)
- [Python](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html)
- [Java](https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html)
- [Go](https://docs.aws.amazon.com/lambda/latest/dg/go-handler.html)

Only exception: 
- [C#](https://docs.aws.amazon.com/lambda/latest/dg/csharp-handler.html)

To ensure general documentation is easier to understand, I would vote that we get in line with AWS, as we [did here](https://github.com/swift-server/swift-aws-lambda-runtime/pull/74).

### Changes

This pr get's our naming in line with AWS' naming.

- Rename `payload` to `event`

I'm well aware that this is a breaking change. But I think we should get those breaking changes out as soon as possible. The barrier for breaking changes will only increase every day by now.

### Open ends

There are some `payload`s left to fix, especially in the Documentation. I'll get those out, if we decide this is something we want to pursue.