### PR TITLE
Rename `payload` to `event`

### DIFF
--- a/Examples/LambdaFunctions/Sources/APIGateway/main.swift
+++ b/Examples/LambdaFunctions/Sources/APIGateway/main.swift
@@ -27,7 +27,7 @@ struct APIGatewayProxyLambda: EventLoopLambdaHandler {
     public typealias In = APIGateway.V2.Request
     public typealias Out = APIGateway.V2.Response
 
-    public func handle(context: Lambda.Context, payload: APIGateway.V2.Request) -> EventLoopFuture<APIGateway.V2.Response> {
+    public func handle(context: Lambda.Context, event: APIGateway.V2.Request) -> EventLoopFuture<APIGateway.V2.Response> {
         context.logger.debug("hello, api gateway!")
         return context.eventLoop.makeSucceededFuture(APIGateway.V2.Response(statusCode: .ok, body: "hello, world!"))
     }

--- a/Examples/LambdaFunctions/Sources/Benchmark/main.swift
+++ b/Examples/LambdaFunctions/Sources/Benchmark/main.swift
@@ -25,7 +25,7 @@ struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
+    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture("hello, world!")
     }
 }

--- a/Examples/LocalDebugging/README.md
+++ b/Examples/LocalDebugging/README.md
@@ -23,8 +23,8 @@ Start with running the `MyLambda` target.
 * Set the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable to `true` by editing the `MyLambda` scheme under `Run`.
 * Hit `Run`
 * Once it is up you should see a log message in the Xcode console saying
-`LocalLambdaServer started and listening on 127.0.0.1:7000, receiving payloads on /invoke`
-which means the local emulator is up and receiving traffic on port `7000` and expecting payloads on the `/invoke` endpoint.
+`LocalLambdaServer started and listening on 127.0.0.1:7000, receiving events on /invoke`
+which means the local emulator is up and receiving traffic on port `7000` and expecting events on the `/invoke` endpoint.
 
 Continue to run the `MyApp` target
 * Switch to the `MyApp` scheme and select a simulator destination.

--- a/Sources/AWSLambdaEvents/Cloudwatch.swift
+++ b/Sources/AWSLambdaEvents/Cloudwatch.swift
@@ -14,7 +14,7 @@
 
 import struct Foundation.Date
 
-/// EventBridge has the same payloads/notification types as CloudWatch
+/// EventBridge has the same events/notification types as CloudWatch
 typealias EventBridge = Cloudwatch
 
 public protocol CloudwatchDetail: Decodable {
@@ -66,7 +66,7 @@ public enum Cloudwatch {
 
             let detailType = try container.decode(String.self, forKey: .detailType)
             guard detailType.lowercased() == Detail.name.lowercased() else {
-                throw PayloadTypeMismatch(name: detailType, type: Detail.self)
+                throw DetailTypeMismatch(name: detailType, type: Detail.self)
             }
 
             self.detail = try container.decode(Detail.self, forKey: .detail)
@@ -122,7 +122,7 @@ public enum Cloudwatch {
         }
     }
 
-    struct PayloadTypeMismatch: Error {
+    struct DetailTypeMismatch: Error {
         let name: String
         let type: Any
     }

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -18,7 +18,7 @@ import class Foundation.JSONEncoder
 import NIO
 import NIOFoundationCompat
 
-/// Extension to the `Lambda` companion to enable execution of Lambdas that take and return `Codable` payloads.
+/// Extension to the `Lambda` companion to enable execution of Lambdas that take and return `Codable` events.
 extension Lambda {
     /// An asynchronous Lambda Closure that takes a `In: Decodable` and returns a `Result<Out: Encodable, Error>` via a completion handler.
     public typealias CodableClosure<In: Decodable, Out: Encodable> = (Lambda.Context, In, @escaping (Result<Out, Error>) -> Void) -> Void
@@ -57,8 +57,8 @@ internal struct CodableClosureWrapper<In: Decodable, Out: Encodable>: LambdaHand
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 
@@ -72,8 +72,8 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 

--- a/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
@@ -23,15 +23,15 @@ import NIOHTTP1
 // For example:
 //
 // try Lambda.withLocalServer {
-//     Lambda.run { (context: Lambda.Context, payload: String, callback: @escaping (Result<String, Error>) -> Void) in
-//         callback(.success("Hello, \(payload)!"))
+//     Lambda.run { (context: Lambda.Context, event: String, callback: @escaping (Result<String, Error>) -> Void) in
+//         callback(.success("Hello, \(event)!"))
 //     }
 // }
 extension Lambda {
     /// Execute code in the context of a mock Lambda server.
     ///
     /// - parameters:
-    ///     - invocationEndpoint: The endpoint  to post payloads to.
+    ///     - invocationEndpoint: The endpoint  to post events to.
     ///     - body: Code to run within the context of the mock server. Typically this would be a Lambda.run function call.
     ///
     /// - note: This API is designed stricly for local testing and is behind a DEBUG flag
@@ -77,7 +77,7 @@ private enum LocalLambda {
                 guard channel.localAddress != nil else {
                     return channel.eventLoop.makeFailedFuture(ServerError.cantBind)
                 }
-                self.logger.info("LocalLambdaServer started and listening on \(self.host):\(self.port), receiving payloads on \(self.invocationEndpoint)")
+                self.logger.info("LocalLambdaServer started and listening on \(self.host):\(self.port), receiving events on \(self.invocationEndpoint)")
                 return channel.eventLoop.makeSucceededFuture(())
             }
         }

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIO
 
-/// Extension to the `Lambda` companion to enable execution of Lambdas that take and return `String` payloads.
+/// Extension to the `Lambda` companion to enable execution of Lambdas that take and return `String` events.
 extension Lambda {
     /// An asynchronous Lambda Closure that takes a `String` and returns a `Result<String, Error>` via a completion handler.
     public typealias StringClosure = (Lambda.Context, String, @escaping (Result<String, Error>) -> Void) -> Void
@@ -64,8 +64,8 @@ internal struct StringClosureWrapper: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 
@@ -79,8 +79,8 @@ internal struct StringVoidClosureWrapper: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, payload, callback)
+    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+        self.closure(context, event, callback)
     }
 }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -51,12 +51,12 @@ extension Lambda {
             self.isGettingNextInvocation = true
             return self.runtimeClient.getNextInvocation(logger: logger).peekError { error in
                 logger.error("could not fetch work from lambda runtime engine: \(error)")
-            }.flatMap { invocation, payload in
+            }.flatMap { invocation, event in
                 // 2. send invocation to handler
                 self.isGettingNextInvocation = false
                 let context = Context(logger: logger, eventLoop: self.eventLoop, invocation: invocation)
                 logger.debug("sending invocation to lambda handler \(handler)")
-                return handler.handle(context: context, payload: payload)
+                return handler.handle(context: context, event: event)
                     .mapResult { result in
                         if case .failure(let error) = result {
                             logger.warning("lambda handler returned an error: \(error)")

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -41,10 +41,10 @@ extension Lambda {
                     throw RuntimeError.badStatusCode(response.status)
                 }
                 let invocation = try Invocation(headers: response.headers)
-                guard let payload = response.body else {
+                guard let event = response.body else {
                     throw RuntimeError.noBody
                 }
-                return (invocation, payload)
+                return (invocation, event)
             }.flatMapErrorThrowing { error in
                 switch error {
                 case HTTPClient.Errors.timeout:

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -22,8 +22,8 @@
 //         typealias In = String
 //         typealias Out = String
 //
-//         func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
-//             return context.eventLoop.makeSucceededFuture("echo" + payload)
+//         func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+//             return context.eventLoop.makeSucceededFuture("echo" + event)
 //         }
 //     }
 //
@@ -59,36 +59,36 @@ extension Lambda {
     }
 
     public static func test(_ closure: @escaping Lambda.StringClosure,
-                            with payload: String,
+                            with event: String,
                             using config: TestConfig = .init()) throws -> String {
-        try Self.test(StringClosureWrapper(closure), with: payload, using: config)
+        try Self.test(StringClosureWrapper(closure), with: event, using: config)
     }
 
     public static func test(_ closure: @escaping Lambda.StringVoidClosure,
-                            with payload: String,
+                            with event: String,
                             using config: TestConfig = .init()) throws {
-        _ = try Self.test(StringVoidClosureWrapper(closure), with: payload, using: config)
+        _ = try Self.test(StringVoidClosureWrapper(closure), with: event, using: config)
     }
 
     public static func test<In: Decodable, Out: Encodable>(
         _ closure: @escaping Lambda.CodableClosure<In, Out>,
-        with payload: In,
+        with event: In,
         using config: TestConfig = .init()
     ) throws -> Out {
-        try Self.test(CodableClosureWrapper(closure), with: payload, using: config)
+        try Self.test(CodableClosureWrapper(closure), with: event, using: config)
     }
 
     public static func test<In: Decodable>(
         _ closure: @escaping Lambda.CodableVoidClosure<In>,
-        with payload: In,
+        with event: In,
         using config: TestConfig = .init()
     ) throws {
-        _ = try Self.test(CodableVoidClosureWrapper(closure), with: payload, using: config)
+        _ = try Self.test(CodableVoidClosureWrapper(closure), with: event, using: config)
     }
 
     public static func test<In, Out, Handler: EventLoopLambdaHandler>(
         _ handler: Handler,
-        with payload: In,
+        with event: In,
         using config: TestConfig = .init()
     ) throws -> Out where Handler.In == In, Handler.Out == Out {
         let logger = Logger(label: "test")
@@ -105,7 +105,7 @@ extension Lambda {
                               eventLoop: eventLoop)
 
         return try eventLoop.flatSubmit {
-            handler.handle(context: context, payload: payload)
+            handler.handle(context: context, event: event)
         }.wait()
     }
 }

--- a/Sources/CodableSample/main.swift
+++ b/Sources/CodableSample/main.swift
@@ -29,9 +29,9 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = Request
     typealias Out = Response
 
-    func handle(context: Lambda.Context, payload: Request) -> EventLoopFuture<Response> {
-        // as an example, respond with the reverse the input payload
-        context.eventLoop.makeSucceededFuture(Response(body: String(payload.body.reversed())))
+    func handle(context: Lambda.Context, event: Request) -> EventLoopFuture<Response> {
+        // as an example, respond with the input event's reversed body
+        context.eventLoop.makeSucceededFuture(Response(body: String(event.body.reversed())))
     }
 }
 

--- a/Sources/StringSample/main.swift
+++ b/Sources/StringSample/main.swift
@@ -20,9 +20,9 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
-        // as an example, respond with the reverse the input payload
-        context.eventLoop.makeSucceededFuture(String(payload.reversed()))
+    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+        // as an example, respond with the event's reversed body
+        context.eventLoop.makeSucceededFuture(String(event.reversed()))
     }
 }
 
@@ -31,7 +31,7 @@ Lambda.run(Handler())
 // MARK: - this can also be expressed as a closure:
 
 /*
- Lambda.run { (_, payload: String, callback) in
-   callback(.success(String(payload.reversed())))
+ Lambda.run { (_, event: String, callback) in
+   callback(.success(String(event.reversed())))
  }
  */

--- a/Tests/AWSLambdaEventsTests/ALBTests.swift
+++ b/Tests/AWSLambdaEventsTests/ALBTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class ALBTests: XCTestCase {
-    static let exampleSingleValueHeadersPayload = """
+    static let exampleSingleValueHeadersEventBody = """
     {
       "requestContext":{
         "elb":{
@@ -44,8 +44,8 @@ class ALBTests: XCTestCase {
     }
     """
 
-    func testRequestWithSingleValueHeadersPayload() {
-        let data = ALBTests.exampleSingleValueHeadersPayload.data(using: .utf8)!
+    func testRequestWithSingleValueHeadersEvent() {
+        let data = ALBTests.exampleSingleValueHeadersEventBody.data(using: .utf8)!
         do {
             let decoder = JSONDecoder()
 

--- a/Tests/AWSLambdaEventsTests/APIGateway+V2Tests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGateway+V2Tests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class APIGatewayV2Tests: XCTestCase {
-    static let exampleGetPayload = """
+    static let exampleGetEventBody = """
     {
         "routeKey":"GET /hello",
         "version":"2.0",
@@ -77,7 +77,7 @@ class APIGatewayV2Tests: XCTestCase {
     // MARK: Decoding
 
     func testRequestDecodingExampleGetRequest() {
-        let data = APIGatewayV2Tests.exampleGetPayload.data(using: .utf8)!
+        let data = APIGatewayV2Tests.exampleGetEventBody.data(using: .utf8)!
         var req: APIGateway.V2.Request?
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGateway.V2.Request.self, from: data))
 

--- a/Tests/AWSLambdaEventsTests/APIGatewayTests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGatewayTests.swift
@@ -16,11 +16,11 @@
 import XCTest
 
 class APIGatewayTests: XCTestCase {
-    static let exampleGetPayload = """
+    static let exampleGetEventBody = """
       {"httpMethod": "GET", "body": null, "resource": "/test", "requestContext": {"resourceId": "123456", "apiId": "1234567890", "resourcePath": "/test", "httpMethod": "GET", "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef", "accountId": "123456789012", "stage": "Prod", "identity": {"apiKey": null, "userArn": null, "cognitoAuthenticationType": null, "caller": null, "userAgent": "Custom User Agent String", "user": null, "cognitoIdentityPoolId": null, "cognitoAuthenticationProvider": null, "sourceIp": "127.0.0.1", "accountId": null}, "extendedRequestId": null, "path": "/test"}, "queryStringParameters": null, "multiValueQueryStringParameters": null, "headers": {"Host": "127.0.0.1:3000", "Connection": "keep-alive", "Cache-Control": "max-age=0", "Dnt": "1", "Upgrade-Insecure-Requests": "1", "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36 Edg/78.0.276.24", "Sec-Fetch-User": "?1", "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3", "Sec-Fetch-Site": "none", "Sec-Fetch-Mode": "navigate", "Accept-Encoding": "gzip, deflate, br", "Accept-Language": "en-US,en;q=0.9", "X-Forwarded-Proto": "http", "X-Forwarded-Port": "3000"}, "multiValueHeaders": {"Host": ["127.0.0.1:3000"], "Connection": ["keep-alive"], "Cache-Control": ["max-age=0"], "Dnt": ["1"], "Upgrade-Insecure-Requests": ["1"], "User-Agent": ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36 Edg/78.0.276.24"], "Sec-Fetch-User": ["?1"], "Accept": ["text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3"], "Sec-Fetch-Site": ["none"], "Sec-Fetch-Mode": ["navigate"], "Accept-Encoding": ["gzip, deflate, br"], "Accept-Language": ["en-US,en;q=0.9"], "X-Forwarded-Proto": ["http"], "X-Forwarded-Port": ["3000"]}, "pathParameters": null, "stageVariables": null, "path": "/test", "isBase64Encoded": false}
     """
 
-    static let todoPostPayload = """
+    static let todoPostEventBody = """
       {"httpMethod": "POST", "body": "{\\"title\\":\\"a todo\\"}", "resource": "/todos", "requestContext": {"resourceId": "123456", "apiId": "1234567890", "resourcePath": "/todos", "httpMethod": "POST", "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef", "accountId": "123456789012", "stage": "test", "identity": {"apiKey": null, "userArn": null, "cognitoAuthenticationType": null, "caller": null, "userAgent": "Custom User Agent String", "user": null, "cognitoIdentityPoolId": null, "cognitoAuthenticationProvider": null, "sourceIp": "127.0.0.1", "accountId": null}, "extendedRequestId": null, "path": "/todos"}, "queryStringParameters": null, "multiValueQueryStringParameters": null, "headers": {"Host": "127.0.0.1:3000", "Connection": "keep-alive", "Content-Length": "18", "Pragma": "no-cache", "Cache-Control": "no-cache", "Accept": "text/plain, */*; q=0.01", "Origin": "http://todobackend.com", "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.36 Safari/537.36 Edg/79.0.309.25", "Dnt": "1", "Content-Type": "application/json", "Sec-Fetch-Site": "cross-site", "Sec-Fetch-Mode": "cors", "Referer": "http://todobackend.com/specs/index.html?http://127.0.0.1:3000/todos", "Accept-Encoding": "gzip, deflate, br", "Accept-Language": "en-US,en;q=0.9", "X-Forwarded-Proto": "http", "X-Forwarded-Port": "3000"}, "multiValueHeaders": {"Host": ["127.0.0.1:3000"], "Connection": ["keep-alive"], "Content-Length": ["18"], "Pragma": ["no-cache"], "Cache-Control": ["no-cache"], "Accept": ["text/plain, */*; q=0.01"], "Origin": ["http://todobackend.com"], "User-Agent": ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.36 Safari/537.36 Edg/79.0.309.25"], "Dnt": ["1"], "Content-Type": ["application/json"], "Sec-Fetch-Site": ["cross-site"], "Sec-Fetch-Mode": ["cors"], "Referer": ["http://todobackend.com/specs/index.html?http://127.0.0.1:3000/todos"], "Accept-Encoding": ["gzip, deflate, br"], "Accept-Language": ["en-US,en;q=0.9"], "X-Forwarded-Proto": ["http"], "X-Forwarded-Port": ["3000"]}, "pathParameters": null, "stageVariables": null, "path": "/todos", "isBase64Encoded": false}
     """
 
@@ -29,7 +29,7 @@ class APIGatewayTests: XCTestCase {
     // MARK: Decoding
 
     func testRequestDecodingExampleGetRequest() {
-        let data = APIGatewayTests.exampleGetPayload.data(using: .utf8)!
+        let data = APIGatewayTests.exampleGetEventBody.data(using: .utf8)!
         var req: APIGateway.Request?
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGateway.Request.self, from: data))
 
@@ -38,7 +38,7 @@ class APIGatewayTests: XCTestCase {
     }
 
     func testRequestDecodingTodoPostRequest() {
-        let data = APIGatewayTests.todoPostPayload.data(using: .utf8)!
+        let data = APIGatewayTests.todoPostEventBody.data(using: .utf8)!
         var req: APIGateway.Request?
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGateway.Request.self, from: data))
 

--- a/Tests/AWSLambdaEventsTests/CloudwatchTests.swift
+++ b/Tests/AWSLambdaEventsTests/CloudwatchTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class CloudwatchTests: XCTestCase {
-    static func eventPayload(type: String, details: String) -> String {
+    static func eventBody(type: String, details: String) -> String {
         """
         {
           "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
@@ -34,8 +34,8 @@ class CloudwatchTests: XCTestCase {
     }
 
     func testScheduledEventFromJSON() {
-        let payload = CloudwatchTests.eventPayload(type: Cloudwatch.Scheduled.name, details: "{}")
-        let data = payload.data(using: .utf8)!
+        let eventBody = CloudwatchTests.eventBody(type: Cloudwatch.Scheduled.name, details: "{}")
+        let data = eventBody.data(using: .utf8)!
         var maybeEvent: Cloudwatch.ScheduledEvent?
         XCTAssertNoThrow(maybeEvent = try JSONDecoder().decode(Cloudwatch.ScheduledEvent.self, from: data))
 
@@ -52,9 +52,9 @@ class CloudwatchTests: XCTestCase {
     }
 
     func testEC2InstanceStateChangeNotificationEventFromJSON() {
-        let payload = CloudwatchTests.eventPayload(type: Cloudwatch.EC2.InstanceStateChangeNotification.name,
-                                                   details: "{ \"instance-id\": \"0\", \"state\": \"stopping\" }")
-        let data = payload.data(using: .utf8)!
+        let eventBody = CloudwatchTests.eventBody(type: Cloudwatch.EC2.InstanceStateChangeNotification.name,
+                                                  details: "{ \"instance-id\": \"0\", \"state\": \"stopping\" }")
+        let data = eventBody.data(using: .utf8)!
         var maybeEvent: Cloudwatch.EC2.InstanceStateChangeNotificationEvent?
         XCTAssertNoThrow(maybeEvent = try JSONDecoder().decode(Cloudwatch.EC2.InstanceStateChangeNotificationEvent.self, from: data))
 
@@ -73,9 +73,9 @@ class CloudwatchTests: XCTestCase {
     }
 
     func testEC2SpotInstanceInterruptionNoticeEventFromJSON() {
-        let payload = CloudwatchTests.eventPayload(type: Cloudwatch.EC2.SpotInstanceInterruptionNotice.name,
-                                                   details: "{ \"instance-id\": \"0\", \"instance-action\": \"terminate\" }")
-        let data = payload.data(using: .utf8)!
+        let eventBody = CloudwatchTests.eventBody(type: Cloudwatch.EC2.SpotInstanceInterruptionNotice.name,
+                                                  details: "{ \"instance-id\": \"0\", \"instance-action\": \"terminate\" }")
+        let data = eventBody.data(using: .utf8)!
         var maybeEvent: Cloudwatch.EC2.SpotInstanceInterruptionNoticeEvent?
         XCTAssertNoThrow(maybeEvent = try JSONDecoder().decode(Cloudwatch.EC2.SpotInstanceInterruptionNoticeEvent.self, from: data))
 
@@ -100,8 +100,8 @@ class CloudwatchTests: XCTestCase {
             let name: String
         }
 
-        let payload = CloudwatchTests.eventPayload(type: Custom.name, details: "{ \"name\": \"foo\" }")
-        let data = payload.data(using: .utf8)!
+        let eventBody = CloudwatchTests.eventBody(type: Custom.name, details: "{ \"name\": \"foo\" }")
+        let data = eventBody.data(using: .utf8)!
         var maybeEvent: Cloudwatch.Event<Custom>?
         XCTAssertNoThrow(maybeEvent = try JSONDecoder().decode(Cloudwatch.Event<Custom>.self, from: data))
 
@@ -119,19 +119,19 @@ class CloudwatchTests: XCTestCase {
     }
 
     func testUnregistredType() {
-        let payload = CloudwatchTests.eventPayload(type: UUID().uuidString, details: "{}")
-        let data = payload.data(using: .utf8)!
+        let eventBody = CloudwatchTests.eventBody(type: UUID().uuidString, details: "{}")
+        let data = eventBody.data(using: .utf8)!
         XCTAssertThrowsError(try JSONDecoder().decode(Cloudwatch.ScheduledEvent.self, from: data)) { error in
-            XCTAssert(error is Cloudwatch.PayloadTypeMismatch, "expected PayloadTypeMismatch but received \(error)")
+            XCTAssert(error is Cloudwatch.DetailTypeMismatch, "expected DetailTypeMismatch but received \(error)")
         }
     }
 
     func testTypeMismatch() {
-        let payload = CloudwatchTests.eventPayload(type: Cloudwatch.EC2.InstanceStateChangeNotification.name,
-                                                   details: "{ \"instance-id\": \"0\", \"state\": \"stopping\" }")
-        let data = payload.data(using: .utf8)!
+        let eventBody = CloudwatchTests.eventBody(type: Cloudwatch.EC2.InstanceStateChangeNotification.name,
+                                                  details: "{ \"instance-id\": \"0\", \"state\": \"stopping\" }")
+        let data = eventBody.data(using: .utf8)!
         XCTAssertThrowsError(try JSONDecoder().decode(Cloudwatch.ScheduledEvent.self, from: data)) { error in
-            XCTAssert(error is Cloudwatch.PayloadTypeMismatch, "expected PayloadTypeMismatch but received \(error)")
+            XCTAssert(error is Cloudwatch.DetailTypeMismatch, "expected DetailTypeMismatch but received \(error)")
         }
     }
 }

--- a/Tests/AWSLambdaEventsTests/DynamoDBTests.swift
+++ b/Tests/AWSLambdaEventsTests/DynamoDBTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class DynamoDBTests: XCTestCase {
-    static let streamEventPayload = """
+    static let streamEventBody = """
     {
       "Records": [
         {
@@ -113,7 +113,7 @@ class DynamoDBTests: XCTestCase {
     """
 
     func testEventFromJSON() {
-        let data = DynamoDBTests.streamEventPayload.data(using: .utf8)!
+        let data = DynamoDBTests.streamEventBody.data(using: .utf8)!
         var event: DynamoDB.Event?
         XCTAssertNoThrow(event = try JSONDecoder().decode(DynamoDB.Event.self, from: data))
 

--- a/Tests/AWSLambdaEventsTests/S3Tests.swift
+++ b/Tests/AWSLambdaEventsTests/S3Tests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class S3Tests: XCTestCase {
-    static let eventPayload = """
+    static let eventBody = """
     {
       "Records": [
         {
@@ -58,7 +58,7 @@ class S3Tests: XCTestCase {
     """
 
     func testSimpleEventFromJSON() {
-        let data = S3Tests.eventPayload.data(using: .utf8)!
+        let data = S3Tests.eventBody.data(using: .utf8)!
         var event: S3.Event?
         XCTAssertNoThrow(event = try JSONDecoder().decode(S3.Event.self, from: data))
 

--- a/Tests/AWSLambdaEventsTests/SNSTests.swift
+++ b/Tests/AWSLambdaEventsTests/SNSTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class SNSTests: XCTestCase {
-    static let eventPayload = """
+    static let eventBody = """
     {
       "Records": [
         {
@@ -51,7 +51,7 @@ class SNSTests: XCTestCase {
     """
 
     func testSimpleEventFromJSON() {
-        let data = SNSTests.eventPayload.data(using: .utf8)!
+        let data = SNSTests.eventBody.data(using: .utf8)!
         var event: SNS.Event?
         XCTAssertNoThrow(event = try JSONDecoder().decode(SNS.Event.self, from: data))
 

--- a/Tests/AWSLambdaEventsTests/SQSTests.swift
+++ b/Tests/AWSLambdaEventsTests/SQSTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class SQSTests: XCTestCase {
-    static let testPayload = """
+    static let eventBody = """
     {
       "Records": [
         {
@@ -60,7 +60,7 @@ class SQSTests: XCTestCase {
     """
 
     func testSimpleEventFromJSON() {
-        let data = SQSTests.testPayload.data(using: .utf8)!
+        let data = SQSTests.eventBody.data(using: .utf8)!
         var event: SQS.Event?
         XCTAssertNoThrow(event = try JSONDecoder().decode(SQS.Event.self, from: data))
 

--- a/Tests/AWSLambdaRuntimeCoreTests/Lambda+StringTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Lambda+StringTest.swift
@@ -26,8 +26,8 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
-                callback(.success(payload))
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+                callback(.success(event))
             }
         }
 
@@ -46,7 +46,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<Void, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
                 callback(.success(()))
             }
         }
@@ -66,7 +66,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("boom")))
             }
         }
@@ -86,8 +86,8 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
-                context.eventLoop.makeSucceededFuture(payload)
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+                context.eventLoop.makeSucceededFuture(event)
             }
         }
 
@@ -106,7 +106,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<Void> {
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
             }
         }
@@ -126,7 +126,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }
@@ -144,8 +144,8 @@ class StringLambdaTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration) { (_, payload: String, callback) in
-            callback(.success(payload))
+        let result = Lambda.run(configuration: configuration) { (_, event: String, callback) in
+            callback(.success(event))
         }
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
@@ -189,7 +189,7 @@ class StringLambdaTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("should not be called")))
             }
         }
@@ -201,17 +201,17 @@ class StringLambdaTest: XCTestCase {
 
 private struct Behavior: LambdaServerBehavior {
     let requestId: String
-    let payload: String
+    let event: String
     let result: Result<String?, TestError>
 
-    init(requestId: String = UUID().uuidString, payload: String = "hello", result: Result<String?, TestError> = .success("hello")) {
+    init(requestId: String = UUID().uuidString, event: String = "hello", result: Result<String?, TestError> = .success("hello")) {
         self.requestId = requestId
-        self.payload = payload
+        self.event = event
         self.result = result
     }
 
     func getInvocation() -> GetInvocationResult {
-        .success((requestId: self.requestId, payload: self.payload))
+        .success((requestId: self.requestId, event: self.event))
     }
 
     func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
@@ -19,14 +19,14 @@ class LambdaRunnerTest: XCTestCase {
     func testSuccess() {
         struct Behavior: LambdaServerBehavior {
             let requestId = UUID().uuidString
-            let payload = "hello"
+            let event = "hello"
             func getInvocation() -> GetInvocationResult {
-                .success((self.requestId, self.payload))
+                .success((self.requestId, self.event))
             }
 
             func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {
                 XCTAssertEqual(self.requestId, requestId, "expecting requestId to match")
-                XCTAssertEqual(self.payload, response, "expecting response to match")
+                XCTAssertEqual(self.event, response, "expecting response to match")
                 return .success(())
             }
 
@@ -48,7 +48,7 @@ class LambdaRunnerTest: XCTestCase {
             static let error = "boom"
             let requestId = UUID().uuidString
             func getInvocation() -> GetInvocationResult {
-                .success((requestId: self.requestId, payload: "hello"))
+                .success((requestId: self.requestId, event: "hello"))
             }
 
             func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTest.swift
@@ -118,7 +118,7 @@ class LambdaRuntimeClientTest: XCTestCase {
     func testProcessResponseInternalServerError() {
         struct Behavior: LambdaServerBehavior {
             func getInvocation() -> GetInvocationResult {
-                .success((requestId: "1", payload: "payload"))
+                .success((requestId: "1", event: "event"))
             }
 
             func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {
@@ -143,7 +143,7 @@ class LambdaRuntimeClientTest: XCTestCase {
     func testProcessErrorInternalServerError() {
         struct Behavior: LambdaServerBehavior {
             func getInvocation() -> GetInvocationResult {
-                .success((requestId: "1", payload: "payload"))
+                .success((requestId: "1", event: "event"))
             }
 
             func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -56,8 +56,8 @@ class LambdaTest: XCTestCase {
                 self.initialized = true
             }
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
-                callback(.success(payload))
+            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+                callback(.success(event))
             }
         }
 
@@ -89,7 +89,7 @@ class LambdaTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(context: Lambda.Context, payload: String, callback: (Result<Void, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
                 callback(.failure(TestError("should not be called")))
             }
         }
@@ -156,7 +156,7 @@ class LambdaTest: XCTestCase {
 
     func testTimeout() {
         let timeout: Int64 = 100
-        let server = MockLambdaServer(behavior: Behavior(requestId: "timeout", payload: "\(timeout * 2)"))
+        let server = MockLambdaServer(behavior: Behavior(requestId: "timeout", event: "\(timeout * 2)"))
         XCTAssertNoThrow(try server.start().wait())
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
@@ -176,9 +176,9 @@ class LambdaTest: XCTestCase {
         assertLambdaLifecycleResult(result, shouldFailWithError: Lambda.RuntimeError.upstreamError("connectionResetByPeer"))
     }
 
-    func testBigPayload() {
-        let payload = String(repeating: "*", count: 104_448)
-        let server = MockLambdaServer(behavior: Behavior(payload: payload, result: .success(payload)))
+    func testBigEvent() {
+        let event = String(repeating: "*", count: 104_448)
+        let server = MockLambdaServer(behavior: Behavior(event: event, result: .success(event)))
         XCTAssertNoThrow(try server.start().wait())
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
@@ -293,17 +293,17 @@ class LambdaTest: XCTestCase {
 
 private struct Behavior: LambdaServerBehavior {
     let requestId: String
-    let payload: String
+    let event: String
     let result: Result<String?, TestError>
 
-    init(requestId: String = UUID().uuidString, payload: String = "hello", result: Result<String?, TestError> = .success("hello")) {
+    init(requestId: String = UUID().uuidString, event: String = "hello", result: Result<String?, TestError> = .success("hello")) {
         self.requestId = requestId
-        self.payload = payload
+        self.event = event
         self.result = result
     }
 
     func getInvocation() -> GetInvocationResult {
-        .success((requestId: self.requestId, payload: self.payload))
+        .success((requestId: self.requestId, event: self.event))
     }
 
     func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -38,8 +38,8 @@ struct EchoHandler: LambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
-        callback(.success(payload))
+    func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+        callback(.success(event))
     }
 }
 
@@ -53,7 +53,7 @@ struct FailedHandler: LambdaHandler {
         self.reason = reason
     }
 
-    func handle(context: Lambda.Context, payload: String, callback: (Result<Void, Error>) -> Void) {
+    func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
         callback(.failure(TestError(self.reason)))
     }
 }

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -42,7 +42,7 @@ class CodableLambdaTest: XCTestCase {
         }
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), payload: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
         XCTAssertNil(outputBuffer)
     }
 
@@ -58,7 +58,7 @@ class CodableLambdaTest: XCTestCase {
         }
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), payload: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
         XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
         XCTAssertEqual(response?.requestId, request.requestId)
     }

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -63,9 +63,9 @@ class LambdaTestingTests: XCTestCase {
             typealias In = Request
             typealias Out = Response
 
-            func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
                 XCTAssertFalse(context.eventLoop.inEventLoop)
-                callback(.success(Response(message: "echo" + payload.name)))
+                callback(.success(Response(message: "echo" + event.name)))
             }
         }
 
@@ -80,9 +80,9 @@ class LambdaTestingTests: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
+            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
                 XCTAssertTrue(context.eventLoop.inEventLoop)
-                return context.eventLoop.makeSucceededFuture("echo" + payload)
+                return context.eventLoop.makeSucceededFuture("echo" + event)
             }
         }
 
@@ -99,7 +99,7 @@ class LambdaTestingTests: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: In, callback: @escaping (Result<Out, Error>) -> Void) {
+            func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
                 callback(.failure(MyError()))
             }
         }


### PR DESCRIPTION
This is the continuation of my work in #112. I've moved the branch to my fork though, because of [reasons](https://twitter.com/johannesweiss/status/1268821987448836096?s=21).

### Motivation

As @Andrea-Scuderi has correctly [pointed out here](https://github.com/swift-server/swift-aws-lambda-runtime/issues/89#issuecomment-636500412), we should follow with our naming AWS closely. Currently the inputs name on all our handler protocols is `payload`, whereas AWS uses `event` in nearly all its languages:

- [Ruby](https://docs.aws.amazon.com/lambda/latest/dg/ruby-handler.html)
- [Node](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html)
- [Python](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html)
- [Java](https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html)
- [Go](https://docs.aws.amazon.com/lambda/latest/dg/go-handler.html)

Only exception: 
- [C#](https://docs.aws.amazon.com/lambda/latest/dg/csharp-handler.html)

To ensure general documentation is easier to understand, I would vote that we get in line with AWS, as we [did here](https://github.com/swift-server/swift-aws-lambda-runtime/pull/74).

### Changes

This pr get's our naming in line with AWS' naming.

- Rename `payload` to `event`

I'm well aware that this is a breaking change. But I think we should get those breaking changes out as soon as possible. The barrier for breaking changes will only increase every day by now.