### PR TITLE
add syncShutdown to LambdaHandler

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -67,7 +67,7 @@ public extension LambdaHandler {
         let promise = context.eventLoop.makePromise(of: Void.self)
         self.offloadQueue.async {
             do {
-                try self.syncShutdown()
+                try self.syncShutdown(context: context)
                 promise.succeed(())
             } catch {
                 promise.fail(error)
@@ -76,9 +76,9 @@ public extension LambdaHandler {
         return promise.futureResult
     }
 
-    /// Clean up the `LambdaHandler` resources synchronously.
+    /// Clean up the Lambda resources synchronously.
     /// Concrete Lambda handlers implement this method to shutdown resources like `HTTPClient`s and database connections.
-    func syncShutdown() throws {
+    func syncShutdown(context: Lambda.ShutdownContext) throws {
         // noop
     }
 }
@@ -186,8 +186,8 @@ public protocol ByteBufferLambdaHandler {
     ///            The `EventLoopFuture` should be completed with either a response encoded as `ByteBuffer` or an `Error`
     func handle(context: Lambda.Context, event: ByteBuffer) -> EventLoopFuture<ByteBuffer?>
 
-    /// The method to clean up your resources.
-    /// Concrete Lambda handlers implement this method to shutdown their `HTTPClient`s and database connections.
+    /// Clean up the Lambda resources asynchronously.
+    /// Concrete Lambda handlers implement this method to shutdown resources like `HTTPClient`s and database connections.
     ///
     /// - Note: In case your Lambda fails while creating your LambdaHandler in the `HandlerFactory`, this method
     ///         **is not invoked**. In this case you must cleanup the created resources immediately in the `HandlerFactory`.


### PR DESCRIPTION
motivation: make shutdown easier to use

changes:
* override shutdown to use the offloadQueue to perform syncShutdown
* add empty syncShutdown that can be implemented by the concrete Lambda function