### PR TITLE
!context reordering context towards common guideline / style for context passing

### DIFF
--- a/Examples/LambdaFunctions/Sources/APIGateway/main.swift
+++ b/Examples/LambdaFunctions/Sources/APIGateway/main.swift
@@ -27,7 +27,7 @@ struct APIGatewayProxyLambda: EventLoopLambdaHandler {
     public typealias In = APIGateway.V2.Request
     public typealias Out = APIGateway.V2.Response
 
-    public func handle(context: Lambda.Context, event: APIGateway.V2.Request) -> EventLoopFuture<APIGateway.V2.Response> {
+    public func handle(event: APIGateway.V2.Request, context: Lambda.Context) -> EventLoopFuture<APIGateway.V2.Response> {
         context.logger.debug("hello, api gateway!")
         return context.eventLoop.makeSucceededFuture(APIGateway.V2.Response(statusCode: .ok, body: "hello, world!"))
     }

--- a/Examples/LambdaFunctions/Sources/Benchmark/main.swift
+++ b/Examples/LambdaFunctions/Sources/Benchmark/main.swift
@@ -25,7 +25,7 @@ struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture("hello, world!")
     }
 }

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -21,7 +21,7 @@ import NIOFoundationCompat
 /// Extension to the `Lambda` companion to enable execution of Lambdas that take and return `Codable` events.
 extension Lambda {
     /// An asynchronous Lambda Closure that takes a `In: Decodable` and returns a `Result<Out: Encodable, Error>` via a completion handler.
-    public typealias CodableClosure<In: Decodable, Out: Encodable> = (Lambda.Context, In, @escaping (Result<Out, Error>) -> Void) -> Void
+    public typealias CodableClosure<In: Decodable, Out: Encodable> = (In, Lambda.Context, @escaping (Result<Out, Error>) -> Void) -> Void
 
     /// Run a Lambda defined by implementing the `CodableClosure` function.
     ///
@@ -34,7 +34,7 @@ extension Lambda {
     }
 
     /// An asynchronous Lambda Closure that takes a `In: Decodable` and returns a `Result<Void, Error>` via a completion handler.
-    public typealias CodableVoidClosure<In: Decodable> = (Lambda.Context, In, @escaping (Result<Void, Error>) -> Void) -> Void
+    public typealias CodableVoidClosure<In: Decodable> = (In, Lambda.Context, @escaping (Result<Void, Error>) -> Void) -> Void
 
     /// Run a Lambda defined by implementing the `CodableVoidClosure` function.
     ///
@@ -57,8 +57,8 @@ internal struct CodableClosureWrapper<In: Decodable, Out: Encodable>: LambdaHand
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, event, callback)
+    func handle(event: In, context: Lambda.Context, callback: @escaping (Result<Out, Error>) -> Void) {
+                self.closure(event, context, callback)
     }
 }
 
@@ -72,8 +72,8 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, event, callback)
+    func handle(event: In, context: Lambda.Context, callback: @escaping (Result<Out, Error>) -> Void) {
+                self.closure(event, context, callback)
     }
 }
 

--- a/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
@@ -23,7 +23,7 @@ import NIOHTTP1
 // For example:
 //
 // try Lambda.withLocalServer {
-//     Lambda.run { (context: Lambda.Context, event: String, callback: @escaping (Result<String, Error>) -> Void) in
+//     Lambda.run { (event: String, context: Lambda.Context, callback: @escaping (Result<String, Error>) -> Void) in
 //         callback(.success("Hello, \(event)!"))
 //     }
 // }

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -16,7 +16,7 @@ import NIO
 /// Extension to the `Lambda` companion to enable execution of Lambdas that take and return `String` events.
 extension Lambda {
     /// An asynchronous Lambda Closure that takes a `String` and returns a `Result<String, Error>` via a completion handler.
-    public typealias StringClosure = (Lambda.Context, String, @escaping (Result<String, Error>) -> Void) -> Void
+    public typealias StringClosure = (String, Lambda.Context, @escaping (Result<String, Error>) -> Void) -> Void
 
     /// Run a Lambda defined by implementing the `StringClosure` function.
     ///
@@ -29,7 +29,7 @@ extension Lambda {
     }
 
     /// An asynchronous Lambda Closure that takes a `String` and returns a `Result<Void, Error>` via a completion handler.
-    public typealias StringVoidClosure = (Lambda.Context, String, @escaping (Result<Void, Error>) -> Void) -> Void
+    public typealias StringVoidClosure = (String, Lambda.Context, @escaping (Result<Void, Error>) -> Void) -> Void
 
     /// Run a Lambda defined by implementing the `StringVoidClosure` function.
     ///
@@ -64,8 +64,8 @@ internal struct StringClosureWrapper: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, event, callback)
+    func handle(event: In, context: Lambda.Context, callback: @escaping (Result<Out, Error>) -> Void) {
+                self.closure(event, context, callback)
     }
 }
 
@@ -79,8 +79,8 @@ internal struct StringVoidClosureWrapper: LambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
-        self.closure(context, event, callback)
+    func handle(event: In, context: Lambda.Context, callback: @escaping (Result<Out, Error>) -> Void) {
+                self.closure(event, context, callback)
     }
 }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -70,7 +70,7 @@ extension Lambda {
                                       allocator: self.allocator,
                                       invocation: invocation)
                 logger.debug("sending invocation to lambda handler \(handler)")
-                return handler.handle(context: context, event: event)
+                return handler.handle(event: event, context: context)
                     // Hopping back to "our" EventLoop is importnant in case the handler returns a future that
                     // originiated from a foreign EventLoop/EventLoopGroup.
                     // This can happen if the handler uses a library (lets say a DB client) that manages its own threads/loops

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -22,7 +22,7 @@
 //         typealias In = String
 //         typealias Out = String
 //
-//         func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+//         func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
 //             return context.eventLoop.makeSucceededFuture("echo" + event)
 //         }
 //     }
@@ -106,7 +106,7 @@ extension Lambda {
                               allocator: ByteBufferAllocator())
 
         return try eventLoop.flatSubmit {
-            handler.handle(context: context, event: event)
+            handler.handle(event: event, context: context)
         }.wait()
     }
 }

--- a/Sources/CodableSample/main.swift
+++ b/Sources/CodableSample/main.swift
@@ -29,7 +29,7 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = Request
     typealias Out = Response
 
-    func handle(context: Lambda.Context, event: Request) -> EventLoopFuture<Response> {
+    func handle(event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
         // as an example, respond with the input event's reversed body
         context.eventLoop.makeSucceededFuture(Response(body: String(event.body.reversed())))
     }
@@ -40,7 +40,7 @@ Lambda.run(Handler())
 // MARK: - this can also be expressed as a closure:
 
 /*
- Lambda.run { (_, request: Request, callback) in
+ Lambda.run { (request: Request, context, callback) in
    callback(.success(Response(body: String(request.body.reversed()))))
  }
  */

--- a/Sources/StringSample/main.swift
+++ b/Sources/StringSample/main.swift
@@ -20,7 +20,7 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         // as an example, respond with the event's reversed body
         context.eventLoop.makeSucceededFuture(String(event.reversed()))
     }
@@ -31,7 +31,7 @@ Lambda.run(Handler())
 // MARK: - this can also be expressed as a closure:
 
 /*
- Lambda.run { (_, event: String, callback) in
+ Lambda.run { (event: String, context, callback) in
    callback(.success(String(event.reversed())))
  }
  */

--- a/Tests/AWSLambdaRuntimeCoreTests/Lambda+StringTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Lambda+StringTest.swift
@@ -26,7 +26,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+            func handle(event: String, context: Lambda.Context, callback: (Result<String, Error>) -> Void) {
                 callback(.success(event))
             }
         }
@@ -34,7 +34,7 @@ class StringLambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: Handler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testVoidCallbackSuccess() {
@@ -46,7 +46,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
+            func handle(event: String, context: Lambda.Context, callback: (Result<Void, Error>) -> Void) {
                 callback(.success(()))
             }
         }
@@ -54,7 +54,7 @@ class StringLambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: Handler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testCallbackFailure() {
@@ -66,7 +66,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+            func handle(event: String, context: Lambda.Context, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("boom")))
             }
         }
@@ -74,7 +74,7 @@ class StringLambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: Handler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testEventLoopSuccess() {
@@ -86,7 +86,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeSucceededFuture(event)
             }
         }
@@ -94,7 +94,7 @@ class StringLambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: Handler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testVoidEventLoopSuccess() {
@@ -106,7 +106,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<Void> {
+            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
             }
         }
@@ -114,7 +114,7 @@ class StringLambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: Handler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testEventLoopFailure() {
@@ -126,7 +126,7 @@ class StringLambdaTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }
@@ -134,7 +134,7 @@ class StringLambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: Handler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testClosureSuccess() {
@@ -144,10 +144,10 @@ class StringLambdaTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration) { (_, event: String, callback) in
+        let result = Lambda.run(configuration: configuration) { (event: String, context, callback) in
             callback(.success(event))
         }
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testVoidClosureSuccess() {
@@ -157,10 +157,10 @@ class StringLambdaTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration) { (_, _: String, callback) in
+        let result = Lambda.run(configuration: configuration) { (_: String, context, callback) in
             callback(.success(()))
         }
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testClosureFailure() {
@@ -170,10 +170,10 @@ class StringLambdaTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result: Result<Int, Error> = Lambda.run(configuration: configuration) { (_, _: String, callback: (Result<String, Error>) -> Void) in
+        let result: Result<Int, Error> = Lambda.run(configuration: configuration) { (_: String, _, callback: (Result<String, Error>) -> Void) in
             callback(.failure(TestError("boom")))
         }
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testBootstrapFailure() {
@@ -189,7 +189,7 @@ class StringLambdaTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+            func handle(event: String, context: Lambda.Context, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("should not be called")))
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
@@ -53,7 +53,7 @@ class LambdaLifecycleTest: XCTestCase {
             self.shutdown = shutdown
         }
 
-        func handle(context: Lambda.Context, event: ByteBuffer) -> EventLoopFuture<ByteBuffer?> {
+        func handle(event: ByteBuffer, context: Lambda.Context) -> EventLoopFuture<ByteBuffer?> {
             self.handler(context, event)
         }
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -26,7 +26,7 @@ class LambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 10 ... 20)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: EchoHandler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testFailure() {
@@ -37,7 +37,7 @@ class LambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 10 ... 20)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: FailedHandler("boom"))
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testBootstrapOnce() {
@@ -56,7 +56,7 @@ class LambdaTest: XCTestCase {
                 self.initialized = true
             }
 
-            func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+            func handle(event: String, context: Lambda.Context, callback: (Result<String, Error>) -> Void) {
                 callback(.success(event))
             }
         }
@@ -64,7 +64,7 @@ class LambdaTest: XCTestCase {
         let maxTimes = Int.random(in: 10 ... 20)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, factory: Handler.init)
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testBootstrapFailure() {
@@ -89,7 +89,7 @@ class LambdaTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
+            func handle(event: String, context: Lambda.Context, callback: (Result<Void, Error>) -> Void) {
                 callback(.failure(TestError("should not be called")))
             }
         }
@@ -184,7 +184,7 @@ class LambdaTest: XCTestCase {
 
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: 1))
         let result = Lambda.run(configuration: configuration, handler: EchoHandler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: 1)
+        assertLambdaLifecycleResult(result, shouldHaveRun: 1)
     }
 
     func testKeepAliveServer() {
@@ -195,7 +195,7 @@ class LambdaTest: XCTestCase {
         let maxTimes = 10
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: EchoHandler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testNoKeepAliveServer() {
@@ -206,7 +206,7 @@ class LambdaTest: XCTestCase {
         let maxTimes = 10
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
         let result = Lambda.run(configuration: configuration, handler: EchoHandler())
-        assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
+        assertLambdaLifecycleResult(result, shouldHaveRun: maxTimes)
     }
 
     func testServerFailure() {

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -38,7 +38,7 @@ struct EchoHandler: LambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, event: String, callback: (Result<String, Error>) -> Void) {
+    func handle(event: String, context: Lambda.Context, callback: (Result<String, Error>) -> Void) {
         callback(.success(event))
     }
 }
@@ -53,17 +53,17 @@ struct FailedHandler: LambdaHandler {
         self.reason = reason
     }
 
-    func handle(context: Lambda.Context, event: String, callback: (Result<Void, Error>) -> Void) {
+    func handle(event: String, context: Lambda.Context, callback: (Result<Void, Error>) -> Void) {
         callback(.failure(TestError(self.reason)))
     }
 }
 
-func assertLambdaLifecycleResult(_ result: Result<Int, Error>, shoudHaveRun: Int = 0, shouldFailWithError: Error? = nil, file: StaticString = #file, line: UInt = #line) {
+func assertLambdaLifecycleResult(_ result: Result<Int, Error>, shouldHaveRun: Int = 0, shouldFailWithError: Error? = nil, file: StaticString = #file, line: UInt = #line) {
     switch result {
     case .success where shouldFailWithError != nil:
         XCTFail("should fail with \(shouldFailWithError!)", file: file, line: line)
     case .success(let count) where shouldFailWithError == nil:
-        XCTAssertEqual(shoudHaveRun, count, "should have run \(shoudHaveRun) times", file: file, line: line)
+        XCTAssertEqual(shouldHaveRun, count, "should have run \(shouldHaveRun) times", file: file, line: line)
     case .failure(let error) where shouldFailWithError == nil:
         XCTFail("should succeed, but failed with \(error)", file: file, line: line)
     case .failure(let error) where shouldFailWithError != nil:

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -36,13 +36,13 @@ class CodableLambdaTest: XCTestCase {
         var inputBuffer: ByteBuffer?
         var outputBuffer: ByteBuffer?
 
-        let closureWrapper = CodableVoidClosureWrapper { (_, _: Request, completion) in
+        let closureWrapper = CodableVoidClosureWrapper { (_: Request, _, completion) in
             XCTAssertEqual(request, request)
             completion(.success(()))
         }
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
         XCTAssertNil(outputBuffer)
     }
 
@@ -52,13 +52,13 @@ class CodableLambdaTest: XCTestCase {
         var outputBuffer: ByteBuffer?
         var response: Response?
 
-        let closureWrapper = CodableClosureWrapper { (_, req: Request, completion: (Result<Response, Error>) -> Void) in
+        let closureWrapper = CodableClosureWrapper { (req: Request, _, completion: (Result<Response, Error>) -> Void) in
             XCTAssertEqual(request, request)
             completion(.success(Response(requestId: req.requestId)))
         }
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
         XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
         XCTAssertEqual(response?.requestId, request.requestId)
     }

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -27,7 +27,7 @@ class LambdaTestingTests: XCTestCase {
             let message: String
         }
 
-        let myLambda = { (_: Lambda.Context, request: Request, callback: (Result<Response, Error>) -> Void) in
+        let myLambda = { (request: Request, _: Lambda.Context, callback: (Result<Response, Error>) -> Void) in
             callback(.success(Response(message: "echo" + request.name)))
         }
 
@@ -42,7 +42,7 @@ class LambdaTestingTests: XCTestCase {
             let name: String
         }
 
-        let myLambda = { (_: Lambda.Context, _: Request, callback: (Result<Void, Error>) -> Void) in
+        let myLambda = { (_: Request, _: Lambda.Context, callback: (Result<Void, Error>) -> Void) in
             callback(.success(()))
         }
 
@@ -63,7 +63,7 @@ class LambdaTestingTests: XCTestCase {
             typealias In = Request
             typealias Out = Response
 
-            func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+            func handle(event: In, context: Lambda.Context, callback: @escaping (Result<Out, Error>) -> Void) {
                 XCTAssertFalse(context.eventLoop.inEventLoop)
                 callback(.success(Response(message: "echo" + event.name)))
             }
@@ -80,7 +80,7 @@ class LambdaTestingTests: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 XCTAssertTrue(context.eventLoop.inEventLoop)
                 return context.eventLoop.makeSucceededFuture("echo" + event)
             }
@@ -99,7 +99,7 @@ class LambdaTestingTests: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, event: In, callback: @escaping (Result<Out, Error>) -> Void) {
+            func handle(event: In, context: Lambda.Context, callback: @escaping (Result<Out, Error>) -> Void) {
                 callback(.failure(MyError()))
             }
         }
@@ -111,7 +111,7 @@ class LambdaTestingTests: XCTestCase {
 
     func testAsyncLongRunning() {
         var executed: Bool = false
-        let myLambda = { (_: Lambda.Context, _: String, callback: @escaping (Result<Void, Error>) -> Void) in
+        let myLambda = { (_: String, _: Lambda.Context, callback: @escaping (Result<Void, Error>) -> Void) in
             DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.5) {
                 executed = true
                 callback(.success(()))
@@ -131,7 +131,7 @@ class LambdaTestingTests: XCTestCase {
             timeout: .seconds(4)
         )
 
-        let myLambda = { (ctx: Lambda.Context, _: String, callback: @escaping (Result<Void, Error>) -> Void) in
+        let myLambda = { (_: String, ctx: Lambda.Context, callback: @escaping (Result<Void, Error>) -> Void) in
             XCTAssertEqual(ctx.requestID, config.requestID)
             XCTAssertEqual(ctx.traceID, config.traceID)
             XCTAssertEqual(ctx.invokedFunctionARN, config.invokedFunctionARN)


### PR DESCRIPTION
PR for discussing and potentially merging the context reordering, in accordance with some guidelines around context passing style we're trying to align SSWG projects on.

This is not yet set in stone but since I had a moment between bigger tasks wanted to get this PR out of the way so we can sit on it for a bit.

### Motivation:

This PR contains the full writeup of the guidelines we are considering for contexts in general: https://github.com/slashmo/gsoc-swift-baggage-context/pull/2/files

It's about the baggage context but it applies to contexts in general, and I think we're pretty close to aligning many libs to this style; including gRPC (already is), HTTPClient (kind of is, with Logger today and baggage context in the future) other Lambda SDKs as well. 

### Modifications:

Reorder context parameter.

### Result:

- Resolves #89