### PR TITLE
RFC: Added ServiceLifecycle dependency and started integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
 //        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", .upToNextMajor(from: "1.0.0-alpha")),
-        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", .branch("master")),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", .branch("main")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.17.0")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
+//        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", .upToNextMajor(from: "1.0.0-alpha")),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", .branch("master")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [
@@ -29,6 +31,7 @@ let package = Package(
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
+            .product(name: "Lifecycle", package: "swift-service-lifecycle"),
         ]),
         .testTarget(name: "AWSLambdaRuntimeCoreTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+import Lifecycle
 import Logging
 import NIO
 
@@ -32,13 +33,17 @@ extension Lambda {
         /// - note: The `EventLoop` is shared with the Lambda runtime engine and should be handled with extra care.
         ///         Most importantly the `EventLoop` must never be blocked.
         public let eventLoop: EventLoop
+        
+        /// `ServiceLifecycle` to register services with
+        public let serviceLifecycle: ServiceLifecycle
 
         /// `ByteBufferAllocator` to allocate `ByteBuffer`
         public let allocator: ByteBufferAllocator
 
-        internal init(logger: Logger, eventLoop: EventLoop, allocator: ByteBufferAllocator) {
+        internal init(logger: Logger, eventLoop: EventLoop, serviceLifecycle: ServiceLifecycle, allocator: ByteBufferAllocator) {
             self.eventLoop = eventLoop
             self.logger = logger
+            self.serviceLifecycle = serviceLifecycle
             self.allocator = allocator
         }
     }


### PR DESCRIPTION
The current start and shutdown services is okay but not great. Thankfully `ServiceLifecycle` has been released two days ago. Let's see if we can use it for AWS Lambda Runtime.

This is a draft pr, exploring possibilities and starting a discussion.

### Open ends/questions

- In the first approach we only expose the `ServiceLifecycle` to the user but don't use it ourselves, even though we could. But for this we will need to think about state handling (current state of mind):
  - Currently lambda can be shutdown because of two reasons: 
    - The user cancels the process (only possible for DEBUG builds)
    - The Lambda can not communicate correctly with the Control Plane API
  - We could handle the first shutdown case with the new ServiceLifecycle fairly easy.
- Do we want to deprecate the shutdown methods? So that those can be removed before `1.0`?


