### PR TITLE
Remove section about static linking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ To deploy Lambda functions to AWS Lambda, you need to compile the code for Amazo
 
 AWS offers several tools to interact and deploy Lambda functions to AWS Lambda including [SAM](https://aws.amazon.com/serverless/sam/) and the [AWS CLI](https://aws.amazon.com/cli/). The [Examples Directory](/Examples) includes complete sample build and deployment scripts that utilize these tools.
 
-Note the examples mentioned above use dynamic linking, therefore bundle the required Swift libraries in the Zip package along side the executable. You may choose to link the Lambda function statically (using `-static-stdlib`) which could improve performance but requires additional linker flags.
+Note the examples mentioned above use dynamic linking, therefore bundle the required Swift libraries in the Zip package along side the executable.
 
 To build the Lambda function for Amazon Linux, use the Docker image published by Swift.org on [Swift toolchains and Docker images for Amazon Linux 2](https://swift.org/download/), as demonstrated in the examples.
 


### PR DESCRIPTION

Static linking doesn't work on Linux

### Motivation:

It is currently not possible to statically link binaries on Linux due to this bug:

https://bugs.swift.org/browse/SR-648

### Modifications:

README only.

### Result:

README only.
I am not sure if it is worth adding note about that to README?
