### PR TITLE
give better error when lambda fails to start

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
@@ -35,11 +35,10 @@ extension Lambda {
     ///     - body: Code to run within the context of the mock server. Typically this would be a Lambda.run function call.
     ///
     /// - note: This API is designed stricly for local testing and is behind a DEBUG flag
-    @discardableResult
-    static func withLocalServer<Value>(invocationEndpoint: String? = nil, _ body: @escaping () -> Value) throws -> Value {
+    internal static func withLocalServer<Value>(invocationEndpoint: String? = nil, _ body: @escaping () -> Value) throws -> Value {
         let server = LocalLambda.Server(invocationEndpoint: invocationEndpoint)
         try server.start().wait()
-        defer { try! server.stop() } // FIXME:
+        defer { try! server.stop() }
         return body()
     }
 }

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -25,7 +25,9 @@ extension Lambda {
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     public static func run(_ closure: @escaping StringClosure) {
-        self.run(closure: closure)
+        if case .failure(let error) = self.run(closure: closure) {
+            fatalError("\(error)")
+        }
     }
 
     /// An asynchronous Lambda Closure that takes a `String` and returns a `Result<Void, Error>` via a completion handler.
@@ -38,17 +40,17 @@ extension Lambda {
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     public static func run(_ closure: @escaping StringVoidClosure) {
-        self.run(closure: closure)
+        if case .failure(let error) = self.run(closure: closure) {
+            fatalError("\(error)")
+        }
     }
 
     // for testing
-    @discardableResult
     internal static func run(configuration: Configuration = .init(), closure: @escaping StringClosure) -> Result<Int, Error> {
         self.run(configuration: configuration, handler: StringClosureWrapper(closure))
     }
 
     // for testing
-    @discardableResult
     internal static func run(configuration: Configuration = .init(), closure: @escaping StringVoidClosure) -> Result<Int, Error> {
         self.run(configuration: configuration, handler: StringVoidClosureWrapper(closure))
     }

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -37,7 +37,9 @@ public enum Lambda {
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     public static func run(_ handler: Handler) {
-        self.run(handler: handler)
+        if case .failure(let error) = self.run(handler: handler) {
+            fatalError("\(error)")
+        }
     }
 
     /// Run a Lambda defined by implementing the `LambdaHandler` protocol provided via a `LambdaHandlerFactory`.
@@ -49,7 +51,9 @@ public enum Lambda {
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     public static func run(_ factory: @escaping HandlerFactory) {
-        self.run(factory: factory)
+        if case .failure(let error) = self.run(factory: factory) {
+            fatalError("\(error)")
+        }
     }
 
     /// Run a Lambda defined by implementing the `LambdaHandler` protocol provided via a factory, typically a constructor.
@@ -59,7 +63,9 @@ public enum Lambda {
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     public static func run(_ factory: @escaping (InitializationContext) throws -> Handler) {
-        self.run(factory: factory)
+        if case .failure(let error) = self.run(factory: factory) {
+            fatalError("\(error)")
+        }
     }
 
     /// Utility to access/read environment variables
@@ -71,13 +77,11 @@ public enum Lambda {
     }
 
     // for testing and internal use
-    @discardableResult
     internal static func run(configuration: Configuration = .init(), handler: Handler) -> Result<Int, Error> {
         self.run(configuration: configuration, factory: { $0.eventLoop.makeSucceededFuture(handler) })
     }
 
     // for testing and internal use
-    @discardableResult
     internal static func run(configuration: Configuration = .init(), factory: @escaping (InitializationContext) throws -> Handler) -> Result<Int, Error> {
         self.run(configuration: configuration, factory: { context -> EventLoopFuture<Handler> in
             let promise = context.eventLoop.makePromise(of: Handler.self)
@@ -95,7 +99,6 @@ public enum Lambda {
     }
 
     // for testing and internal use
-    @discardableResult
     internal static func run(configuration: Configuration = .init(), factory: @escaping HandlerFactory) -> Result<Int, Error> {
         let _run = { (configuration: Configuration, factory: @escaping HandlerFactory) -> Result<Int, Error> in
             Backtrace.install()


### PR DESCRIPTION
motivation: in error cases where lamnda fails to start the process fails silently and exists with code 0

changes: change the blocking API to check on the result and fatalError if lambda cannot be started / run

