### PR TITLE
better error message when invoking local lambda server with incorrect http method

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
@@ -149,6 +149,10 @@ private enum LocalLambda {
                     Self.invocations.append(invocation)
                 }
 
+            // lambda invocation using the wrong http method
+            case (_, let url) where url.hasSuffix(self.invocationEndpoint):
+                self.writeResponse(context: context, status: .methodNotAllowed)
+
             // /next endpoint is called by the lambda polling for work
             case (.GET, let url) where url.hasSuffix(Consts.getNextInvocationURLSuffix):
                 // check if our server is in the correct state


### PR DESCRIPTION
motivation: nicer error messages

changes: return 405 when using wrong http method on the lambda invocatoin endpoint (local debug server)
