### PR TITLE
update swift-format to 0.45.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal
 
 # swiftformat (until part of the toolchain)
 
-ARG swiftformat_version=0.44.6
+ARG swiftformat_version=0.45.6
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
 RUN cd $HOME/.tools/swift-format && swift build -c release
 RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat


### PR DESCRIPTION
motivation: swift-format is broken on 5.3

changes: update to 0.45.6 that is compatible with 5.3
