### PR TITLE
RFC: instrument lambda handler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
         // TODO: use swift-tracing when available
-        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.7.0")),
+        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.7.1")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
         // TODO: use swift-tracing when available
-        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.6.1")),
+        //.package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.6.1")),
+        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .branch("feature/foundation")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         .testTarget(name: "AWSLambdaRuntimeTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),
             .byName(name: "AWSLambdaRuntime"),
+            .product(name: "AWSXRayRecorder", package: "aws-xray-sdk-swift"),
         ]),
         .target(name: "AWSLambdaEvents", dependencies: []),
         .testTarget(name: "AWSLambdaEventsTests", dependencies: ["AWSLambdaEvents"]),
@@ -51,6 +52,7 @@ let package = Package(
         .target(name: "AWSLambdaTesting", dependencies: [
             .byName(name: "AWSLambdaRuntime"),
             .product(name: "NIO", package: "swift-nio"),
+            .product(name: "AWSXRayRecorder", package: "aws-xray-sdk-swift"),
         ]),
         .testTarget(name: "AWSLambdaTestingTests", dependencies: ["AWSLambdaTesting"]),
         // for perf testing

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "swift-aws-lambda-runtime",
     platforms: [
-        .macOS(.v10_14), // TODO: fix in aws-xray-sdk-swift
+        .macOS(.v10_14), // TODO: should not be needed soon
     ],
     products: [
         // this library exports `AWSLambdaRuntimeCore` and adds Foundation convenience methods
@@ -19,10 +19,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.17.0")),
+//        .package(url: "https://github.com/pokryfka/swift-nio.git", .branch("feature/tracing")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
         // TODO: use swift-tracing when available
-        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.6.0")),
+        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.6.1")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
         // TODO: use swift-tracing when available
-        //.package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.6.1")),
-        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .branch("feature/foundation")),
+        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.7.0")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "swift-aws-lambda-runtime",
     platforms: [
-        .macOS(.v10_13),
+        .macOS(.v10_14), // TODO: fix in aws-xray-sdk-swift
     ],
     products: [
         // this library exports `AWSLambdaRuntimeCore` and adds Foundation convenience methods
@@ -21,6 +21,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.17.0")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
+        // TODO: use swift-tracing when available
+        .package(url: "https://github.com/pokryfka/aws-xray-sdk-swift.git", .upToNextMinor(from: "0.6.0")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [
@@ -32,6 +34,7 @@ let package = Package(
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
+            .product(name: "AWSXRaySDK", package: "aws-xray-sdk-swift"),
         ]),
         .testTarget(name: "AWSLambdaRuntimeCoreTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -21,6 +21,7 @@ import Darwin.C
 import Backtrace
 import Logging
 import NIO
+import NIOConcurrencyHelpers
 
 public enum Lambda {
     public typealias Handler = ByteBufferLambdaHandler
@@ -29,6 +30,23 @@ public enum Lambda {
     ///
     /// A function that takes a `InitializationContext` and returns an `EventLoopFuture` of a `ByteBufferLambdaHandler`
     public typealias HandlerFactory = (InitializationContext) -> EventLoopFuture<Handler>
+
+    internal typealias TracerFactory = (EventLoop) -> TracingInstrument
+
+    private static let lock = Lock()
+    private static var tracerFactory: TracerFactory = { _ in NoOpTracingInstrument() }
+
+    /// Select the desired `TracingInstrument` implementation.
+    ///
+    /// The caller is responsible for the tracer lifecycle.
+    ///
+    /// - parameters:
+    ///     -  tracerFactory: creates `TracingInstrument` implementation
+    public static func bootstrap(_ tracerFactory: @escaping (EventLoop) -> TracingInstrument) {
+        self.lock.withLockVoid {
+            self.tracerFactory = tracerFactory
+        }
+    }
 
     /// Run a Lambda defined by implementing the `LambdaHandler` protocol.
     ///

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -21,7 +21,6 @@ import Darwin.C
 import Backtrace
 import Logging
 import NIO
-import NIOConcurrencyHelpers
 
 public enum Lambda {
     public typealias Handler = ByteBufferLambdaHandler
@@ -30,23 +29,6 @@ public enum Lambda {
     ///
     /// A function that takes a `InitializationContext` and returns an `EventLoopFuture` of a `ByteBufferLambdaHandler`
     public typealias HandlerFactory = (InitializationContext) -> EventLoopFuture<Handler>
-
-    internal typealias TracerFactory = (EventLoop) -> TracingInstrument
-
-    private static let lock = Lock()
-    private static var tracerFactory: TracerFactory = { _ in NoOpTracingInstrument() }
-
-    /// Select the desired `TracingInstrument` implementation.
-    ///
-    /// The caller is responsible for the tracer lifecycle.
-    ///
-    /// - parameters:
-    ///     -  tracerFactory: creates `TracingInstrument` implementation
-    public static func bootstrap(_ tracerFactory: @escaping (EventLoop) -> TracingInstrument) {
-        self.lock.withLockVoid {
-            self.tracerFactory = tracerFactory
-        }
-    }
 
     /// Run a Lambda defined by implementing the `LambdaHandler` protocol.
     ///

--- a/Sources/AWSLambdaRuntimeCore/LambdaConfiguration.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaConfiguration.swift
@@ -21,19 +21,16 @@ extension Lambda {
         let general: General
         let lifecycle: Lifecycle
         let runtimeEngine: RuntimeEngine
-        let tracerFactory: TracerFactory
 
         init() {
             self.init(general: .init(), lifecycle: .init(), runtimeEngine: .init())
         }
 
-        init(general: General? = nil, lifecycle: Lifecycle? = nil, runtimeEngine: RuntimeEngine? = nil,
-             tracerFactory: TracerFactory? = nil)
+        init(general: General? = nil, lifecycle: Lifecycle? = nil, runtimeEngine: RuntimeEngine? = nil)
         {
             self.general = general ?? General()
             self.lifecycle = lifecycle ?? Lifecycle()
             self.runtimeEngine = runtimeEngine ?? RuntimeEngine()
-            self.tracerFactory = tracerFactory ?? { _ in NoOpTracingInstrument() }
         }
 
         struct General: CustomStringConvertible {

--- a/Sources/AWSLambdaRuntimeCore/LambdaConfiguration.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaConfiguration.swift
@@ -21,15 +21,19 @@ extension Lambda {
         let general: General
         let lifecycle: Lifecycle
         let runtimeEngine: RuntimeEngine
+        let tracerFactory: TracerFactory
 
         init() {
             self.init(general: .init(), lifecycle: .init(), runtimeEngine: .init())
         }
 
-        init(general: General? = nil, lifecycle: Lifecycle? = nil, runtimeEngine: RuntimeEngine? = nil) {
+        init(general: General? = nil, lifecycle: Lifecycle? = nil, runtimeEngine: RuntimeEngine? = nil,
+             tracerFactory: TracerFactory? = nil)
+        {
             self.general = general ?? General()
             self.lifecycle = lifecycle ?? Lifecycle()
             self.runtimeEngine = runtimeEngine ?? RuntimeEngine()
+            self.tracerFactory = tracerFactory ?? { _ in NoOpTracingInstrument() }
         }
 
         struct General: CustomStringConvertible {

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AWSXRayRecorder
+import Baggage
 import Dispatch
 import Logging
 import NIO
@@ -69,7 +70,8 @@ extension Lambda {
         /// For invocations from the AWS Mobile SDK, data about the client application and device.
         public let clientContext: String?
 
-        public let baggage: XRayContext // TODO: use BaggageContext when swift-tracign is ready
+        /// Context baggage.
+        public var baggage: BaggageContext
 
         /// `Logger` to log with
         ///
@@ -114,8 +116,10 @@ extension Lambda {
             var logger = logger
             logger[metadataKey: "awsRequestID"] = .string(requestID)
             logger[metadataKey: "awsTraceID"] = .string(traceID)
-            // TODO: handle error in better way
-            self.baggage = try! XRayContext(tracingHeader: traceID)
+            var baggage = BaggageContext()
+            // TODO: handle error
+            baggage.xRayContext = try? XRayContext(tracingHeader: traceID)
+            self.baggage = baggage
             self.logger = logger
             self.tracer = tracer
         }

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -71,7 +71,7 @@ extension Lambda {
         public let clientContext: String?
 
         /// Context baggage.
-        public var baggage: BaggageContext
+        public let baggage: BaggageContext
 
         /// `Logger` to log with
         ///

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -117,7 +117,7 @@ extension Lambda {
             logger[metadataKey: "awsRequestID"] = .string(requestID)
             logger[metadataKey: "awsTraceID"] = .string(traceID)
             var baggage = BaggageContext()
-            // TODO: handle error
+            // TODO: use `swift-tracing` API, note that we can ONLY extract X-Ray Context from the invocation data
             baggage.xRayContext = try? XRayContext(tracingHeader: traceID)
             self.baggage = baggage
             self.logger = logger

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -140,7 +140,8 @@ public extension EventLoopLambdaHandler {
             return context.eventLoop.makeFailedFuture(CodecError.requestDecoding(error))
         case .success(let `in`):
             let subsegment = segment.beginSubsegment(name: "HandleIn")
-            context.baggage = subsegment.baggage
+            // context is not thread safe, do not change it
+            // context.baggage = subsegment.baggage
             return self.handle(context: context, event: `in`)
                 .endSegment(subsegment)
                 .flatMapThrowing { out in

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -140,8 +140,7 @@ public extension EventLoopLambdaHandler {
             return context.eventLoop.makeFailedFuture(CodecError.requestDecoding(error))
         case .success(let `in`):
             let subsegment = segment.beginSubsegment(name: "HandleIn")
-            // TODO: context is not thread safe, do not change it
-            // context.baggage = subsegment.baggage
+            context.baggage = subsegment.baggage
             return self.handle(context: context, event: `in`)
                 .endSegment(subsegment)
                 .flatMapThrowing { out in

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -129,16 +129,24 @@ public protocol EventLoopLambdaHandler: ByteBufferLambdaHandler {
 public extension EventLoopLambdaHandler {
     /// Driver for `ByteBuffer` -> `In` decoding and `Out` -> `ByteBuffer` encoding
     func handle(context: Lambda.Context, event: ByteBuffer) -> EventLoopFuture<ByteBuffer?> {
-        switch self.decodeIn(buffer: event) {
-        case .failure(let error):
-            return context.eventLoop.makeFailedFuture(CodecError.requestDecoding(error))
-        case .success(let `in`):
-            return self.handle(context: context, event: `in`).flatMapThrowing { out in
-                switch self.encodeOut(allocator: context.allocator, value: out) {
-                case .failure(let error):
-                    throw CodecError.responseEncoding(error)
-                case .success(let buffer):
-                    return buffer
+        // TODO: creating subsegments with NIO which will be easier if the baggage is passes in channel
+        // see https://github.com/slashmo/gsoc-swift-tracing/issues/48
+        context.tracer.segment(name: "HandleEvent", context: context.baggage) {
+            // TODO: create helper to record errors in result types
+            let decodedEvent = context.tracer.segment(name: "DecodeIn", context: context.baggage) { _ in self.decodeIn(buffer: event) }
+            switch decodedEvent {
+            case .failure(let error):
+                return context.eventLoop.makeFailedFuture(CodecError.requestDecoding(error))
+            case .success(let `in`):
+                return self.handle(context: context, event: `in`).flatMapThrowing { out in
+                    try context.tracer.segment(name: "encodeOut", context: context.baggage) { _ in
+                        switch self.encodeOut(allocator: context.allocator, value: out) {
+                        case .failure(let error):
+                            throw CodecError.responseEncoding(error)
+                        case .success(let buffer):
+                            return buffer
+                        }
+                    }
                 }
             }
         }

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -140,7 +140,7 @@ public extension EventLoopLambdaHandler {
             return context.eventLoop.makeFailedFuture(CodecError.requestDecoding(error))
         case .success(let `in`):
             let subsegment = segment.beginSubsegment(name: "HandleIn")
-            // context is not thread safe, do not change it
+            // TODO: context is not thread safe, do not change it
             // context.baggage = subsegment.baggage
             return self.handle(context: context, event: `in`)
                 .endSegment(subsegment)

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -18,13 +18,15 @@ import Dispatch
 import Logging
 import NIO
 
+// type names defined in `TracingInstrument`, aliases will be removed
 public typealias TracingInstrument = XRayRecorder
+public typealias NoOpTracingInstrument = XRayNoOpRecorder
 
 extension Lambda {
     /// LambdaRunner manages the Lambda runtime workflow, or business logic.
     internal final class Runner {
         private let runtimeClient: RuntimeClient
-        internal let tracer: TracingInstrument
+        private let tracer: TracingInstrument
         private let eventLoop: EventLoop
         private let allocator: ByteBufferAllocator
 
@@ -33,7 +35,7 @@ extension Lambda {
         init(eventLoop: EventLoop, configuration: Configuration) {
             self.eventLoop = eventLoop
             self.runtimeClient = RuntimeClient(eventLoop: self.eventLoop, configuration: configuration.runtimeEngine)
-            self.tracer = XRayRecorder(eventLoopGroupProvider: .shared(eventLoop))
+            self.tracer = configuration.tracerFactory(eventLoop)
             self.allocator = ByteBufferAllocator()
         }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -32,9 +32,10 @@ extension Lambda {
 
         private var isGettingNextInvocation = false
 
-        init(eventLoop: EventLoop, configuration: Configuration, tracer: TracingInstrument) {
+        init(eventLoop: EventLoop, configuration: Configuration, tracer: TracingInstrument = NoOpTracingInstrument()) {
             self.eventLoop = eventLoop
-            self.runtimeClient = RuntimeClient(eventLoop: self.eventLoop, configuration: configuration.runtimeEngine, tracer: tracer)
+            self.runtimeClient = RuntimeClient(eventLoop: self.eventLoop, configuration: configuration.runtimeEngine,
+                                               tracer: tracer)
             self.tracer = tracer
             self.allocator = ByteBufferAllocator()
         }

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -61,6 +61,7 @@ extension Lambda {
                 }
         }
 
+        // TODO: instrument custom runtime API
         func run(logger: Logger, handler: Handler) -> EventLoopFuture<Void> {
             logger.debug("lambda invocation sequence starting")
             // 1. request invocation from lambda runtime engine
@@ -93,6 +94,9 @@ extension Lambda {
                 self.runtimeClient.reportResults(logger: logger, invocation: invocation, result: result).peekError { error in
                     logger.error("could not report results to lambda runtime engine: \(error)")
                 }
+            }.flatMap {
+                // flush the tracer after each invocation
+                self.tracer.flush(on: self.eventLoop)
             }
         }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -93,7 +93,7 @@ extension Lambda {
                         }
                         return (invocation, result, baggage)
                     }
-            }.flatMap { (invocation, result, baggage: BaggageContext) in
+            }.flatMap { invocation, result, baggage in
                 // 3. report results to runtime engine
                 self.tracer.segment(name: "ReportResults", baggage: baggage) { _ in
                     self.runtimeClient.reportResults(logger: logger, invocation: invocation, result: result).peekError { error in

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -98,10 +98,9 @@ extension Lambda {
                         logger.error("could not report results to lambda runtime engine: \(error)")
                     }
                 }
-            }.flatMap {
-                // flush the tracer after each invocation
-                self.tracer.flush(on: self.eventLoop)
             }
+            // flush the tracer after each invocation
+            .flush(self.tracer, recover: false)
         }
 
         /// cancels the current run, if we are waiting for next invocation (long poll from Lambda control plane)

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -32,10 +32,10 @@ extension Lambda {
 
         private var isGettingNextInvocation = false
 
-        init(eventLoop: EventLoop, configuration: Configuration) {
+        init(eventLoop: EventLoop, configuration: Configuration, tracer: TracingInstrument) {
             self.eventLoop = eventLoop
             self.runtimeClient = RuntimeClient(eventLoop: self.eventLoop, configuration: configuration.runtimeEngine)
-            self.tracer = configuration.tracerFactory(eventLoop)
+            self.tracer = tracer
             self.allocator = ByteBufferAllocator()
         }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -29,7 +29,8 @@ extension Lambda {
         private let allocator = ByteBufferAllocator()
         private let httpClient: HTTPClient
 
-        init(eventLoop: EventLoop, configuration: Configuration.RuntimeEngine, tracer: TracingInstrument) {
+        init(eventLoop: EventLoop, configuration: Configuration.RuntimeEngine,
+             tracer: TracingInstrument = NoOpTracingInstrument()) {
             self.eventLoop = eventLoop
             self.httpClient = HTTPClient(eventLoop: eventLoop, configuration: configuration, tracer: tracer)
         }

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -38,7 +38,7 @@ extension Lambda {
         func getNextInvocation(logger: Logger) -> EventLoopFuture<(Invocation, ByteBuffer)> {
             let url = Consts.invocationURLPrefix + Consts.getNextInvocationURLSuffix
             logger.debug("requesting work from lambda runtime engine using \(url)")
-            // we will get the trace context in the invocation
+            // we will get the trace context in the invocation response
             return self.httpClient.get(url: url, headers: RuntimeClient.defaultHeaders, context: .init()).flatMapThrowing { response in
                 guard response.status == .ok else {
                     throw RuntimeError.badStatusCode(response.status)

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -36,12 +36,9 @@
 #if DEBUG
 @testable import AWSLambdaRuntime
 @testable import AWSLambdaRuntimeCore
-import AWSXRayRecorder
 import Dispatch
 import Logging
 import NIO
-
-private let noOpTracer = XRayRecorder(emitter: XRayNoOpEmitter())
 
 extension Lambda {
     public struct TestConfig {
@@ -105,7 +102,7 @@ extension Lambda {
                               invokedFunctionARN: config.invokedFunctionARN,
                               deadline: .now() + config.timeout,
                               logger: logger,
-                              tracer: noOpTracer,
+                              tracer: NoOpTracingInstrument(),
                               eventLoop: eventLoop,
                               allocator: ByteBufferAllocator())
 

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -36,9 +36,12 @@
 #if DEBUG
 @testable import AWSLambdaRuntime
 @testable import AWSLambdaRuntimeCore
+import AWSXRayRecorder
 import Dispatch
 import Logging
 import NIO
+
+private let noOpTracer = XRayRecorder(emitter: XRayNoOpEmitter())
 
 extension Lambda {
     public struct TestConfig {
@@ -102,6 +105,7 @@ extension Lambda {
                               invokedFunctionARN: config.invokedFunctionARN,
                               deadline: .now() + config.timeout,
                               logger: logger,
+                              tracer: noOpTracer,
                               eventLoop: eventLoop,
                               allocator: ByteBufferAllocator())
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTest.swift
@@ -263,7 +263,7 @@ class LambdaRuntimeClientTest: XCTestCase {
         XCTAssertNoThrow(inv = try Lambda.Invocation(headers: header))
         guard let invocation = inv else { return }
 
-        let result = client.reportResults(logger: logger, invocation: invocation, result: Result.failure(TestError("boom")))
+        let result = client.reportResults(logger: logger, invocation: invocation, result: Result.failure(TestError("boom")), context: .init())
 
         var inboundHeader: HTTPServerRequestPart?
         XCTAssertNoThrow(inboundHeader = try server.readInbound())
@@ -303,7 +303,8 @@ class LambdaRuntimeClientTest: XCTestCase {
         XCTAssertNoThrow(inv = try Lambda.Invocation(headers: header))
         guard let invocation = inv else { return }
 
-        let result = client.reportResults(logger: logger, invocation: invocation, result: Result.success(nil))
+        let result = client.reportResults(logger: logger, invocation: invocation, result: Result.success(nil),
+                                          context: .init())
 
         var inboundHeader: HTTPServerRequestPart?
         XCTAssertNoThrow(inboundHeader = try server.readInbound())

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -13,12 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 @testable import AWSLambdaRuntimeCore
-import AWSXRayRecorder
 import Logging
 import NIO
 import XCTest
-
-private let noOpTracer = XRayRecorder(emitter: XRayNoOpEmitter())
 
 class LambdaTest: XCTestCase {
     func testSuccess() {
@@ -266,7 +263,7 @@ class LambdaTest: XCTestCase {
                                      cognitoIdentity: nil,
                                      clientContext: nil,
                                      logger: Logger(label: "test"),
-                                     tracer: noOpTracer,
+                                     tracer: NoOpTracingInstrument(),
                                      eventLoop: MultiThreadedEventLoopGroup(numberOfThreads: 1).next(),
                                      allocator: ByteBufferAllocator())
         XCTAssertGreaterThan(context.deadline, .now())
@@ -278,7 +275,7 @@ class LambdaTest: XCTestCase {
                                             cognitoIdentity: context.cognitoIdentity,
                                             clientContext: context.clientContext,
                                             logger: context.logger,
-                                            tracer: noOpTracer,
+                                            tracer: NoOpTracingInstrument(),
                                             eventLoop: context.eventLoop,
                                             allocator: context.allocator)
         XCTAssertLessThan(expiredContext.deadline, .now())
@@ -292,7 +289,7 @@ class LambdaTest: XCTestCase {
                                      cognitoIdentity: nil,
                                      clientContext: nil,
                                      logger: Logger(label: "test"),
-                                     tracer: noOpTracer,
+                                     tracer: NoOpTracingInstrument(),
                                      eventLoop: MultiThreadedEventLoopGroup(numberOfThreads: 1).next(),
                                      allocator: ByteBufferAllocator())
         XCTAssertLessThanOrEqual(context.getRemainingTime(), .seconds(1))

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -13,9 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 @testable import AWSLambdaRuntimeCore
+import AWSXRayRecorder
 import Logging
 import NIO
 import XCTest
+
+private let noOpTracer = XRayRecorder(emitter: XRayNoOpEmitter())
 
 class LambdaTest: XCTestCase {
     func testSuccess() {
@@ -263,6 +266,7 @@ class LambdaTest: XCTestCase {
                                      cognitoIdentity: nil,
                                      clientContext: nil,
                                      logger: Logger(label: "test"),
+                                     tracer: noOpTracer,
                                      eventLoop: MultiThreadedEventLoopGroup(numberOfThreads: 1).next(),
                                      allocator: ByteBufferAllocator())
         XCTAssertGreaterThan(context.deadline, .now())
@@ -274,6 +278,7 @@ class LambdaTest: XCTestCase {
                                             cognitoIdentity: context.cognitoIdentity,
                                             clientContext: context.clientContext,
                                             logger: context.logger,
+                                            tracer: noOpTracer,
                                             eventLoop: context.eventLoop,
                                             allocator: context.allocator)
         XCTAssertLessThan(expiredContext.deadline, .now())
@@ -287,6 +292,7 @@ class LambdaTest: XCTestCase {
                                      cognitoIdentity: nil,
                                      clientContext: nil,
                                      logger: Logger(label: "test"),
+                                     tracer: noOpTracer,
                                      eventLoop: MultiThreadedEventLoopGroup(numberOfThreads: 1).next(),
                                      allocator: ByteBufferAllocator())
         XCTAssertLessThanOrEqual(context.getRemainingTime(), .seconds(1))

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -14,13 +14,10 @@
 
 @testable import AWSLambdaRuntime
 @testable import AWSLambdaRuntimeCore
-import AWSXRayRecorder
 import Logging
 import NIO
 import NIOFoundationCompat
 import XCTest
-
-private let noOpTracer = XRayRecorder(emitter: XRayNoOpEmitter())
 
 class CodableLambdaTest: XCTestCase {
     var eventLoopGroup: EventLoopGroup!
@@ -75,7 +72,7 @@ class CodableLambdaTest: XCTestCase {
                        cognitoIdentity: nil,
                        clientContext: nil,
                        logger: Logger(label: "test"),
-                       tracer: noOpTracer,
+                       tracer: NoOpTracingInstrument(),
                        eventLoop: self.eventLoopGroup.next(),
                        allocator: ByteBufferAllocator())
     }

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -14,10 +14,13 @@
 
 @testable import AWSLambdaRuntime
 @testable import AWSLambdaRuntimeCore
+import AWSXRayRecorder
 import Logging
 import NIO
 import NIOFoundationCompat
 import XCTest
+
+private let noOpTracer = XRayRecorder(emitter: XRayNoOpEmitter())
 
 class CodableLambdaTest: XCTestCase {
     var eventLoopGroup: EventLoopGroup!
@@ -72,6 +75,7 @@ class CodableLambdaTest: XCTestCase {
                        cognitoIdentity: nil,
                        clientContext: nil,
                        logger: Logger(label: "test"),
+                       tracer: noOpTracer,
                        eventLoop: self.eventLoopGroup.next(),
                        allocator: ByteBufferAllocator())
     }


### PR DESCRIPTION
PoC instrumentation of the lambda handler.

### Motivation:

Add support for instrumentation.

### Modifications:

- creates an instance of a tracer (currently `AWSXRayRecorder`) - needs to be configurable
- pass tracer `TracingInstrument` and (context) baggage `BaggageContext` in `Lambda.Context`
- instrument invocation handling
- flushes the tracer after each invocation

### TODO

- [ ] import `swift-tracing` instead of `aws-xray-sdk-swift` to limit dependencies
  - [ ] stable `TracingInstrument` API
- [ ] extend `Lambda` bootstrap to be able to use the same `EventLoop` in an instance of `XRayUDPEmitter`
- [ ] discuss what exactly should be recorder by the handler

### Result:

Example in X-Ray console of handling a simple HelloWorld, cold start, Foundation JSON encoder/decoder.

<img width="1155" alt="Screen Shot 2020-08-14 at 11 08 02" src="https://user-images.githubusercontent.com/5090827/90219043-ce10da80-de37-11ea-86c8-5212de027a9a.png">