### PR TITLE
switch to 5.3 nightly now that it is published

### DIFF
--- a/docker/docker-compose.al2.53.yaml
+++ b/docker/docker-compose.al2.53.yaml
@@ -6,7 +6,7 @@ services:
     image: swift-aws-lambda:al2-5.3
     build:
       args:
-        base_image: "swiftlang/swift:nightly-amazonlinux2"
+        base_image: "swiftlang/swift:nightly-5.3-amazonlinux2"
 
   test:
     image: swift-aws-lambda:al2-5.3


### PR DESCRIPTION
motivation: stable 5.3 ci

changes: pin 5.3 ci jobs to 5.3 nightlies instead of master

