### PR TITLE
Properties of HTTPResponses are now var

### DIFF
--- a/Sources/AWSLambdaEvents/ALB.swift
+++ b/Sources/AWSLambdaEvents/ALB.swift
@@ -51,12 +51,12 @@ public enum ALB {
     }
 
     public struct TargetGroupResponse: Codable {
-        public let statusCode: HTTPResponseStatus
-        public let statusDescription: String?
-        public let headers: HTTPHeaders?
-        public let multiValueHeaders: HTTPMultiValueHeaders?
-        public let body: String
-        public let isBase64Encoded: Bool
+        public var statusCode: HTTPResponseStatus
+        public var statusDescription: String?
+        public var headers: HTTPHeaders?
+        public var multiValueHeaders: HTTPMultiValueHeaders?
+        public var body: String
+        public var isBase64Encoded: Bool
 
         public init(
             statusCode: HTTPResponseStatus,

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -93,24 +93,21 @@ extension APIGateway.V2 {
 
 extension APIGateway.V2 {
     public struct Response: Codable {
-        public let statusCode: HTTPResponseStatus
-        public let headers: HTTPHeaders?
-        public let multiValueHeaders: HTTPMultiValueHeaders?
-        public let body: String?
-        public let isBase64Encoded: Bool?
-        public let cookies: [String]?
+        public var statusCode: HTTPResponseStatus
+        public var headers: HTTPHeaders?
+        public var body: String?
+        public var isBase64Encoded: Bool?
+        public var cookies: [String]?
 
         public init(
             statusCode: HTTPResponseStatus,
             headers: HTTPHeaders? = nil,
-            multiValueHeaders: HTTPMultiValueHeaders? = nil,
             body: String? = nil,
             isBase64Encoded: Bool? = nil,
             cookies: [String]? = nil
         ) {
             self.statusCode = statusCode
             self.headers = headers
-            self.multiValueHeaders = multiValueHeaders
             self.body = body
             self.isBase64Encoded = isBase64Encoded
             self.cookies = cookies

--- a/Sources/AWSLambdaEvents/APIGateway.swift
+++ b/Sources/AWSLambdaEvents/APIGateway.swift
@@ -70,11 +70,11 @@ public enum APIGateway {
 
 extension APIGateway {
     public struct Response: Codable {
-        public let statusCode: HTTPResponseStatus
-        public let headers: HTTPHeaders?
-        public let multiValueHeaders: HTTPMultiValueHeaders?
-        public let body: String?
-        public let isBase64Encoded: Bool?
+        public var statusCode: HTTPResponseStatus
+        public var headers: HTTPHeaders?
+        public var multiValueHeaders: HTTPMultiValueHeaders?
+        public var body: String?
+        public var isBase64Encoded: Bool?
 
         public init(
             statusCode: HTTPResponseStatus,


### PR DESCRIPTION
Properties of HTTPResponse types should be `var` not `let`

### Motivation:

When creating responses in Lambda developers might want to create the response in multiple steps changing and adding properties. As of now this is not possible since all HTTPResponse types only have `let` properties. If a developer wants to mark a response as immutable they have still the option to mark the complete response as `let`.

### Modifications:

- All properties of HTTPResponse types (`APIGateway.Response`, `APIGateway.V2.Response`, `ALB.TargetGroupResponse`) are now `var`iable
- An unsupported property has been removed from `APIGateway.V2.Response`. See [example/documentation at the very end](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)

### Result:

Developers have an easier job creating responses. 🥳