### PR TITLE
Fixed the visibility of the JWT in an API Gateway V2 Request.

### DIFF
--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -37,7 +37,7 @@ extension APIGateway.V2 {
                     public let scopes: [String]?
                 }
 
-                let jwt: JWT
+                public let jwt: JWT
             }
 
             public let accountId: String


### PR DESCRIPTION
Made JWT in API Gateway V2 Request public.

### Motivation:

As noted in this issue
https://github.com/swift-server/swift-aws-lambda-runtime/issues/166
the JWT instance should be public.

### Modifications:

Added the public modifier.

### Result:

The JWT instance will be available for consuming modules.