### PR TITLE
Correct typo in SQS example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,8 +93,8 @@ Next, create a `main.swift` and implement your Lambda.
  import AWSLambdaRuntime
  import AWSLambdaEvents
 
- // In this example we are receiving an SQS Message, with no response (Void).
- Lambda.run { (context, message: SQS.Message, callback: @escaping (Result<Void, Error>) -> Void) in
+ // In this example we are receiving an SQS Event, with no response (Void).
+ Lambda.run { (context, message: SQS.Event, callback: @escaping (Result<Void, Error>) -> Void) in
    ...
    callback(.success(Void()))
  }


### PR DESCRIPTION
_[One line description of your change]_

### Motivation:

Ran into an issue with a proof-of-concept, and after looking through issues, realized this was just a typo in the readme.

### Modifications:

Corrected the comment and code.

### Result:

Example in readme now works correctly with SQS!
