### PR TITLE
Fixing the queryStringParameters variable for ALB

### DIFF
--- a/Sources/AWSLambdaEvents/ALB.swift
+++ b/Sources/AWSLambdaEvents/ALB.swift
@@ -25,7 +25,7 @@ public enum ALB {
 
         public let httpMethod: HTTPMethod
         public let path: String
-        public let queryStringParameters: [String: [String]]
+        public let queryStringParameters: [String: String]
 
         /// Depending on your configuration of your target group either `headers` or `multiValueHeaders`
         /// are set.


### PR DESCRIPTION
Adjusted the `queryStringParameters` to be actually working with ALB.

### Motivation:

I want my Vapor apps to work through Lambda. However, this structure does not properly represent what AWS ALB is sending to the handler. There might be use-cases in which the original implementation is working but it looks fairly untested to me and I could not find the structure, as it is now, in any examples provided by AWS.

### Modifications:

Change `queryStringParameters` from `[String:[String]]` to `[String:String]`.

### Result:

It works with the actual ALB (live example can be provided if desired) and I did not come across any need for the original implementation.
