### PR TITLE
async/await support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,12 +24,12 @@ let package = Package(
             .byName(name: "AWSLambdaRuntimeCore"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
-        ], swiftSettings: [.unsafeFlags(["-Xfrontend", "-enable-experimental-concurrency"])]),
+        ]),
         .target(name: "AWSLambdaRuntimeCore", dependencies: [
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
-        ], swiftSettings: [.unsafeFlags(["-Xfrontend", "-enable-experimental-concurrency"])]),
+        ]),
         .testTarget(name: "AWSLambdaRuntimeCoreTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),
             .product(name: "NIOTestUtils", package: "swift-nio"),
@@ -38,7 +38,7 @@ let package = Package(
         .testTarget(name: "AWSLambdaRuntimeTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),
             .byName(name: "AWSLambdaRuntime"),
-        ], swiftSettings: [.unsafeFlags(["-Xfrontend", "-enable-experimental-concurrency"])]),
+        ]),
         .target(name: "AWSLambdaEvents", dependencies: []),
         .testTarget(name: "AWSLambdaEventsTests", dependencies: ["AWSLambdaEvents"]),
         // testing helper

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "AWSLambdaTesting", targets: ["AWSLambdaTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.28.0")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "AWSLambdaTesting", targets: ["AWSLambdaTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.26.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
     ],
@@ -29,6 +29,7 @@ let package = Package(
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
+            .product(name: "_NIOConcurrency", package: "swift-nio"),
         ]),
         .testTarget(name: "AWSLambdaRuntimeCoreTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .testTarget(name: "AWSLambdaRuntimeTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),
             .byName(name: "AWSLambdaRuntime"),
-        ]),
+        ], swiftSettings: [.unsafeFlags(["-Xfrontend", "-enable-experimental-concurrency"])]),
         .target(name: "AWSLambdaEvents", dependencies: []),
         .testTarget(name: "AWSLambdaEventsTests", dependencies: ["AWSLambdaEvents"]),
         // testing helper

--- a/Package.swift
+++ b/Package.swift
@@ -24,12 +24,12 @@ let package = Package(
             .byName(name: "AWSLambdaRuntimeCore"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
-        ]),
+        ], swiftSettings: [.unsafeFlags(["-Xfrontend", "-enable-experimental-concurrency"])]),
         .target(name: "AWSLambdaRuntimeCore", dependencies: [
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
-        ]),
+        ], swiftSettings: [.unsafeFlags(["-Xfrontend", "-enable-experimental-concurrency"])]),
         .testTarget(name: "AWSLambdaRuntimeCoreTests", dependencies: [
             .byName(name: "AWSLambdaRuntimeCore"),
             .product(name: "NIOTestUtils", package: "swift-nio"),

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -78,62 +78,6 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
     }
 }
 
-// MARK: - Async
-
-#if compiler(>=5.5) && $AsyncAwait
-extension Lambda {
-    /// Run a Lambda defined by implementing the `CodableAsyncClosure` function.
-    ///
-    /// - parameters:
-    ///     - closure: `CodableAsyncClosure` based Lambda.
-    ///
-    /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
-    public static func run<In: Decodable, Out: Encodable>(_ closure: @escaping (In, Lambda.Context) async throws -> Out) {
-        self.run(CodableAsyncWrapper(closure))
-    }
-
-    /// Run a Lambda defined by implementing the `CodableVoidAsyncClosure` function.
-    ///
-    /// - parameters:
-    ///     - closure: `CodableVoidAsyncClosure` based Lambda.
-    ///
-    /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
-    public static func run<In: Decodable>(_ closure: @escaping (In, Lambda.Context) async throws -> Void) {
-        self.run(CodableVoidAsyncWrapper(closure))
-    }
-}
-
-internal struct CodableAsyncWrapper<In: Decodable, Out: Encodable>: AsyncLambdaHandler {
-    typealias In = In
-    typealias Out = Out
-
-    private let closure: (In, Lambda.Context) async throws -> Out
-
-    init(_ closure: @escaping (In, Lambda.Context) async throws -> Out) {
-        self.closure = closure
-    }
-
-    func handle(event: In, context: Lambda.Context) async throws -> Out {
-        try await self.closure(event, context)
-    }
-}
-
-internal struct CodableVoidAsyncWrapper<In: Decodable>: AsyncLambdaHandler {
-    typealias In = In
-    typealias Out = Void
-
-    private let closure: (In, Lambda.Context) async throws -> Void
-
-    init(_ closure: @escaping (In, Lambda.Context) async throws -> Void) {
-        self.closure = closure
-    }
-
-    func handle(event: In, context: Lambda.Context) async throws {
-        try await self.closure(event, context)
-    }
-}
-#endif
-
 // MARK: - Codable support
 
 /// Implementation of  a`ByteBuffer` to `In` decoding

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -80,6 +80,7 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
 
 // MARK: - Async
 
+#if compiler(>=5.4) && $AsyncAwait
 extension Lambda {
     
     /// An async Lambda Closure that takes a `In: Decodable` and returns an `Out: Encodable`
@@ -138,6 +139,7 @@ internal struct CodableVoidAsyncWrapper<In: Decodable>: AsyncLambdaHandler {
         try await self.closure(context, event)
     }
 }
+#endif
 
 // MARK: - Codable support
 

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -80,12 +80,11 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
 
 // MARK: - Async
 
-#if compiler(>=5.4) && $AsyncAwait
+#if compiler(>=5.5) && $AsyncAwait
 extension Lambda {
-    
     /// An async Lambda Closure that takes a `In: Decodable` and returns an `Out: Encodable`
     public typealias CodableAsyncClosure<In: Decodable, Out: Encodable> = (Lambda.Context, In) async throws -> Out
-    
+
     /// Run a Lambda defined by implementing the `CodableAsyncClosure` function.
     ///
     /// - parameters:
@@ -97,7 +96,7 @@ extension Lambda {
     }
 
     /// An asynchronous Lambda Closure that takes a `In: Decodable` and returns nothing.
-    public typealias CodableVoidAsyncClosure<In: Decodable> = (Lambda.Context, In) async throws -> ()
+    public typealias CodableVoidAsyncClosure<In: Decodable> = (Lambda.Context, In) async throws -> Void
 
     /// Run a Lambda defined by implementing the `CodableVoidAsyncClosure` function.
     ///
@@ -135,7 +134,7 @@ internal struct CodableVoidAsyncWrapper<In: Decodable>: AsyncLambdaHandler {
         self.closure = closure
     }
 
-    func handle(context: Lambda.Context, event: In) async throws -> Void {
+    func handle(context: Lambda.Context, event: In) async throws {
         try await self.closure(context, event)
     }
 }

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -57,18 +57,6 @@ public enum Lambda {
         }
     }
 
-    #if compiler(>=5.5) && $AsyncAwait
-    public static func run(_ factory: @escaping (InitializationContext) async throws -> Handler) {
-        self.run { context -> EventLoopFuture<Handler> in
-            let promise = context.eventLoop.makePromise(of: Handler.self)
-            promise.completeWithAsync {
-                try await factory(context)
-            }
-            return promise.futureResult
-        }
-    }
-    #endif
-
     /// Run a Lambda defined by implementing the `LambdaHandler` protocol provided via a factory, typically a constructor.
     ///
     /// - parameters:

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -55,8 +55,8 @@ public enum Lambda {
             fatalError("\(error)")
         }
     }
-    
-    #if compiler(>=5.4) && $AsyncAwait
+
+    #if compiler(>=5.5) && $AsyncAwait
     public static func run(_ factory: @escaping (InitializationContext) async throws -> Handler) {
         self.run { context -> EventLoopFuture<Handler> in
             @asyncHandler func _createLambda(_ context: InitializationContext, promise: EventLoopPromise<Handler>) {
@@ -67,7 +67,7 @@ public enum Lambda {
                     promise.fail(error)
                 }
             }
-            
+
             let promise = context.eventLoop.makePromise(of: Handler.self)
             _createLambda(context, promise: promise)
             return promise.futureResult

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -87,9 +87,18 @@ extension LambdaHandler {
 
 // MARK: - AsyncLambdaHandler
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 /// Strongly typed, processing protocol for a Lambda that takes a user defined `In` and returns a user defined `Out` async.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public protocol AsyncLambdaHandler: EventLoopLambdaHandler {
+    /// The Lambda initialization method
+    /// Use this method to initialize resources that will be used in every request.
+    ///
+    /// Examples for this can be HTTP or database clients.
+    /// - parameters:
+    ///     - context: Runtime `InitializationContext`.
+    init(context: Lambda.InitializationContext) async throws
+
     /// The Lambda handling method
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///
@@ -101,6 +110,7 @@ public protocol AsyncLambdaHandler: EventLoopLambdaHandler {
     func handle(event: In, context: Lambda.Context) async throws -> Out
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncLambdaHandler {
     public func handle(context: Lambda.Context, event: In) -> EventLoopFuture<Out> {
         let promise = context.eventLoop.makePromise(of: Out.self)
@@ -108,6 +118,19 @@ extension AsyncLambdaHandler {
             try await self.handle(event: event, context: context)
         }
         return promise.futureResult
+    }
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension AsyncLambdaHandler {
+    public static func main() {
+        Lambda.run { context -> EventLoopFuture<ByteBufferLambdaHandler> in
+            let promise = context.eventLoop.makePromise(of: ByteBufferLambdaHandler.self)
+            promise.completeWithAsync {
+                try await Self(context: context)
+            }
+            return promise.futureResult
+        }
     }
 }
 #endif

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -110,7 +110,7 @@ extension AsyncLambdaHandler {
 
     @asyncHandler private func _run(context: Lambda.Context, event: In, promise: EventLoopPromise<Out>) {
         do {
-            let result = try await handle(context: context, event: event)
+            let result = try await self.handle(context: context, event: event)
             promise.succeed(result)
         } catch {
             promise.fail(error)

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -87,10 +87,9 @@ extension LambdaHandler {
 
 // MARK: - AsyncLambdaHandler
 
-#if compiler(>=5.4) && $AsyncAwait
+#if compiler(>=5.5) && $AsyncAwait
 /// Strongly typed, processing protocol for a Lambda that takes a user defined `In` and returns a user defined `Out` async.
 public protocol AsyncLambdaHandler: EventLoopLambdaHandler {
-    
     /// The Lambda handling method
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///
@@ -108,7 +107,7 @@ extension AsyncLambdaHandler {
         self._run(context: context, event: event, promise: promise)
         return promise.futureResult
     }
-    
+
     @asyncHandler private func _run(context: Lambda.Context, event: In, promise: EventLoopPromise<Out>) {
         do {
             let result = try await handle(context: context, event: event)

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -17,7 +17,7 @@ import NIO
 import XCTest
 
 class LambdaHandlerTest: XCTestCase {
-    // MARK: Callback
+    // MARK: - Callback
 
     func testCallbackSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
@@ -81,7 +81,7 @@ class LambdaHandlerTest: XCTestCase {
 
     #if compiler(>=5.5) && $AsyncAwait
 
-    // MARK: AsyncLambdaHandler
+    // MARK: - AsyncLambdaHandler
 
     func testAsyncHandlerSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
@@ -142,7 +142,7 @@ class LambdaHandlerTest: XCTestCase {
     }
     #endif
 
-    // MARK: EventLoop
+    // MARK: - EventLoop
 
     func testEventLoopSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
@@ -204,7 +204,7 @@ class LambdaHandlerTest: XCTestCase {
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
 
-    // MARK: Closure
+    // MARK: - Closure
 
     func testClosureSuccess() {
         let server = MockLambdaServer(behavior: Behavior())

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -92,7 +92,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String) async throws -> String {
+            func handle(event: String, context: Lambda.Context) async throws -> String {
                 event
             }
         }
@@ -112,7 +112,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, event: String) async throws {}
+            func handle(event: String, context: Lambda.Context) async throws {}
         }
 
         let maxTimes = Int.random(in: 1 ... 10)
@@ -130,7 +130,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String) async throws -> String {
+            func handle(event: String, context: Lambda.Context) async throws -> String {
                 throw TestError("boom")
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -79,10 +79,11 @@ class LambdaHandlerTest: XCTestCase {
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
 
-    #if compiler(>=5.5) && $AsyncAwait
+    #if compiler(>=5.5)
 
     // MARK: - AsyncLambdaHandler
 
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func testAsyncHandlerSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
         XCTAssertNoThrow(try server.start().wait())
@@ -92,6 +93,8 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
+            init(context: Lambda.InitializationContext) {}
+
             func handle(event: String, context: Lambda.Context) async throws -> String {
                 event
             }
@@ -99,10 +102,11 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handler: Handler())
+        let result = Lambda.run(configuration: configuration, factory: Handler.init)
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
 
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func testVoidAsyncHandlerSuccess() {
         let server = MockLambdaServer(behavior: Behavior(result: .success(nil)))
         XCTAssertNoThrow(try server.start().wait())
@@ -112,15 +116,18 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
+            init(context: Lambda.InitializationContext) {}
+
             func handle(event: String, context: Lambda.Context) async throws {}
         }
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handler: Handler())
+        let result = Lambda.run(configuration: configuration, factory: Handler.init)
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
 
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func testAsyncHandlerFailure() {
         let server = MockLambdaServer(behavior: Behavior(result: .failure(TestError("boom"))))
         XCTAssertNoThrow(try server.start().wait())
@@ -130,6 +137,8 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
+            init(context: Lambda.InitializationContext) {}
+
             func handle(event: String, context: Lambda.Context) async throws -> String {
                 throw TestError("boom")
             }
@@ -137,7 +146,7 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handler: Handler())
+        let result = Lambda.run(configuration: configuration, factory: Handler.init)
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
     #endif

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -62,14 +62,14 @@ class CodableLambdaTest: XCTestCase {
         XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
         XCTAssertEqual(response?.requestId, request.requestId)
     }
-    
-    #if compiler(>=5.4) && $AsyncAwait
+
+    #if compiler(>=5.5) && $AsyncAwait
     func testCodableVoidAsyncWrapper() {
         let request = Request(requestId: UUID().uuidString)
         var inputBuffer: ByteBuffer?
         var outputBuffer: ByteBuffer?
 
-        let closureWrapper = CodableVoidAsyncWrapper { (context, req: Request) in
+        let closureWrapper = CodableVoidAsyncWrapper { (_, req: Request) in
             XCTAssertEqual(request, req)
         }
 
@@ -84,7 +84,7 @@ class CodableLambdaTest: XCTestCase {
         var outputBuffer: ByteBuffer?
         var response: Response?
 
-        let closureWrapper = CodableAsyncWrapper { (context, req: Request) -> Response in
+        let closureWrapper = CodableAsyncWrapper { (_, req: Request) -> Response in
             XCTAssertEqual(req, request)
             return Response(requestId: req.requestId)
         }

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -63,39 +63,6 @@ class CodableLambdaTest: XCTestCase {
         XCTAssertEqual(response?.requestId, request.requestId)
     }
 
-    #if compiler(>=5.5) && $AsyncAwait
-    func testCodableVoidAsyncWrapper() {
-        let request = Request(requestId: UUID().uuidString)
-        var inputBuffer: ByteBuffer?
-        var outputBuffer: ByteBuffer?
-
-        let closureWrapper = CodableVoidAsyncWrapper { (req: Request, _) in
-            XCTAssertEqual(request, req)
-        }
-
-        XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
-        XCTAssertNil(outputBuffer)
-    }
-
-    func testCodableAsyncWrapper() {
-        let request = Request(requestId: UUID().uuidString)
-        var inputBuffer: ByteBuffer?
-        var outputBuffer: ByteBuffer?
-        var response: Response?
-
-        let closureWrapper = CodableAsyncWrapper { (req: Request, _) -> Response in
-            XCTAssertEqual(req, request)
-            return Response(requestId: req.requestId)
-        }
-
-        XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try closureWrapper.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
-        XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
-        XCTAssertEqual(response?.requestId, request.requestId)
-    }
-    #endif
-
     // convencience method
     func newContext() -> Lambda.Context {
         Lambda.Context(requestID: UUID().uuidString,

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -69,7 +69,7 @@ class CodableLambdaTest: XCTestCase {
         var inputBuffer: ByteBuffer?
         var outputBuffer: ByteBuffer?
 
-        let closureWrapper = CodableVoidAsyncWrapper { (_, req: Request) in
+        let closureWrapper = CodableVoidAsyncWrapper { (req: Request, _) in
             XCTAssertEqual(request, req)
         }
 
@@ -84,7 +84,7 @@ class CodableLambdaTest: XCTestCase {
         var outputBuffer: ByteBuffer?
         var response: Response?
 
-        let closureWrapper = CodableAsyncWrapper { (_, req: Request) -> Response in
+        let closureWrapper = CodableAsyncWrapper { (req: Request, _) -> Response in
             XCTAssertEqual(req, request)
             return Response(requestId: req.requestId)
         }

--- a/docker/docker-compose.al2.main.yaml
+++ b/docker/docker-compose.al2.main.yaml
@@ -10,9 +10,14 @@ services:
 
   test:
     image: swift-aws-lambda:al2-main
+    command: /bin/bash -cl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency"
 
   test-samples:
     image: swift-aws-lambda:al2-main
+    command: >-
+      /bin/bash -clx "
+      swift build -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency --package-path Examples/LambdaFunctions &&
+      swift build -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency --package-path Examples/LocalDebugging/MyLambda"
 
   shell:
     image: swift-aws-lambda:al2-main


### PR DESCRIPTION
`async`/`await` is awesome! Let's support this in Lambda.

Modifications:

- Add an `AsyncLambdaHandler`. Will be renamed to `LambdaHandler` as soon as we drop the current callback based `LambdaHandler`.
- The default way to use an `AsyncLambdaHandler` is to use `@main` to execute it. Don't use `Lambda.run` for it. We wan't to remove `Lambda.run` for 1.0.