### PR TITLE
Add Authorizer section to API Gateway Request

### DIFF
--- a/Sources/AWSLambdaEvents/APIGateway.swift
+++ b/Sources/AWSLambdaEvents/APIGateway.swift
@@ -36,6 +36,11 @@ public enum APIGateway {
                 public let accountId: String?
             }
 
+            public struct Authorizer: Codable {
+                public let claims: [String: String]
+                public let scopes: [String]?
+            }
+            
             public let resourceId: String
             public let apiId: String
             public let resourcePath: String
@@ -45,6 +50,7 @@ public enum APIGateway {
             public let stage: String
 
             public let identity: Identity
+            public let authorizer: Authorizer?
             public let extendedRequestId: String?
             public let path: String
         }


### PR DESCRIPTION
Add Authorizer section to API Gateway Request

### Motivation:

As discussed in [issue #147](https://github.com/swift-server/swift-aws-lambda-runtime/issues/147), API Gateway is not decoding the Autorizer section.

That section is required when, for example, inside a Lambda function you need details about a user who is calling the function through a secured API Gateway.


### Modifications:

Added an 'authorizer' key to APIGateway.Request. This key is an optional dictionary of string to string.


### Result:

- After the change, the authorizer key is decoded into API Gateway Request.
- In my tests on AWS, this key contains all the Cognito information sent by API Gateway to my Lambda function.
- Since this is an optional key, it does not affect existing code that does not receive the authorizer data.