### PR TITLE
Update swiftformat

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 # file options
 
---swiftversion 5.1
+--swiftversion 5.2
 --exclude .build
 
 # format options
@@ -9,5 +9,10 @@
 --patternlet inline
 --stripunusedargs unnamed-only
 --ifdef no-indent
+--extensionacl on-declarations
+--disable typeSugar
+--disable andOperator
+--disable wrapMultilineStatementBraces
+--disable enumNamespaces
 
 # rules

--- a/Examples/LambdaFunctions/Sources/CurrencyExchange/main.swift
+++ b/Examples/LambdaFunctions/Sources/CurrencyExchange/main.swift
@@ -104,7 +104,8 @@ struct ExchangeRatesCalculator {
                           monthIndex: Array<Date>.Index,
                           currencies: [String],
                           state: [Date: ExchangeRates],
-                          callback: @escaping ((Result<[Date: ExchangeRates], Swift.Error>) -> Void)) {
+                          callback: @escaping ((Result<[Date: ExchangeRates], Swift.Error>) -> Void))
+    {
         if monthIndex == months.count {
             return callback(.success(state))
         }
@@ -145,16 +146,16 @@ struct ExchangeRatesCalculator {
         dateFormatter.dateFormat = "dd/MMM/yy"
         let interval: DateInterval?
         if let period = try document.nodes(forXPath: "/exchangeRateMonthList/@Period").first?.stringValue,
-            period.count == 26 {
+           period.count == 26 {
             // "01/Sep/2018 to 30/Sep/2018"
             let startString = period[period.startIndex ..< period.index(period.startIndex, offsetBy: 11)]
             let to = period[startString.endIndex ..< period.index(startString.endIndex, offsetBy: 4)]
             let endString = period[to.endIndex ..< period.index(to.endIndex, offsetBy: 11)]
             if let startDate = dateFormatter.date(from: String(startString)),
-                let startDay = calendar.dateInterval(of: .day, for: startDate),
-                to == " to ",
-                let endDate = dateFormatter.date(from: String(endString)),
-                let endDay = calendar.dateInterval(of: .day, for: endDate) {
+               let startDay = calendar.dateInterval(of: .day, for: startDate),
+               to == " to ",
+               let endDate = dateFormatter.date(from: String(endString)),
+               let endDay = calendar.dateInterval(of: .day, for: endDate) {
                 interval = DateInterval(start: startDay.start, end: endDay.end)
             } else {
                 interval = nil
@@ -166,8 +167,8 @@ struct ExchangeRatesCalculator {
         let ratesByCurrencyCode: [String: Decimal?] = Dictionary(uniqueKeysWithValues: try currencyCodes.map {
             let xpathCurrency = $0.replacingOccurrences(of: "'", with: "&apos;")
             if let rateString = try document.nodes(forXPath: "/exchangeRateMonthList/exchangeRate/currencyCode[text()='\(xpathCurrency)']/../rateNew/text()").first?.stringValue,
-                // We must parse the decimal data using the UK locale, not the system one.
-                let rate = Decimal(string: rateString, locale: self.locale) {
+               // We must parse the decimal data using the UK locale, not the system one.
+               let rate = Decimal(string: rateString, locale: self.locale) {
                 return ($0, rate)
             } else {
                 return ($0, nil)

--- a/Sources/AWSLambdaEvents/AppSync.swift
+++ b/Sources/AWSLambdaEvents/AppSync.swift
@@ -146,8 +146,8 @@ public enum AppSync {
     }
 }
 
-public extension AppSync {
-    enum Response<ResultType: Encodable>: Encodable {
+extension AppSync {
+    public enum Response<ResultType: Encodable>: Encodable {
         public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             switch self {
@@ -165,5 +165,5 @@ public extension AppSync {
         case dictionary([String: ResultType])
     }
 
-    typealias JSONStringResponse = Response<String>
+    public typealias JSONStringResponse = Response<String>
 }

--- a/Sources/AWSLambdaEvents/Cloudwatch.swift
+++ b/Sources/AWSLambdaEvents/Cloudwatch.swift
@@ -21,8 +21,8 @@ public protocol CloudwatchDetail: Decodable {
     static var name: String { get }
 }
 
-public extension CloudwatchDetail {
-    var detailType: String {
+extension CloudwatchDetail {
+    public var detailType: String {
         Self.name
     }
 }

--- a/Sources/AWSLambdaEvents/DynamoDB.swift
+++ b/Sources/AWSLambdaEvents/DynamoDB.swift
@@ -15,7 +15,7 @@
 import struct Foundation.Date
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
-public struct DynamoDB {
+public enum DynamoDB {
     public struct Event: Decodable {
         public let records: [EventRecord]
 
@@ -311,14 +311,12 @@ extension DynamoDB {
         public init() {}
 
         @inlinable public func decode<T: Decodable>(_ type: T.Type, from image: [String: AttributeValue])
-            throws -> T
-        {
+            throws -> T {
             try self.decode(type, from: .map(image))
         }
 
         @inlinable public func decode<T: Decodable>(_ type: T.Type, from value: AttributeValue)
-            throws -> T
-        {
+            throws -> T {
             let decoder = _DecoderImpl(userInfo: userInfo, from: value, codingPath: [])
             return try decoder.decode(T.self)
         }
@@ -511,7 +509,7 @@ extension DynamoDB {
 
         func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws
             -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
-            return try self.decoderForKey(key).container(keyedBy: type)
+            try self.decoderForKey(key).container(keyedBy: type)
         }
 
         func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
@@ -557,8 +555,7 @@ extension DynamoDB {
         }
 
         @inline(__always) private func decodeFixedWidthInteger<T: FixedWidthInteger>(key: Self.Key)
-            throws -> T
-        {
+            throws -> T {
             let value = try getValue(forKey: key)
 
             guard case .number(let number) = value else {
@@ -577,8 +574,7 @@ extension DynamoDB {
         }
 
         @inline(__always) private func decodeLosslessStringConvertible<T: LosslessStringConvertible>(
-            key: Self.Key) throws -> T
-        {
+            key: Self.Key) throws -> T {
             let value = try getValue(forKey: key)
 
             guard case .number(let number) = value else {
@@ -677,7 +673,7 @@ extension DynamoDB {
         }
 
         func decode<T>(_: T.Type) throws -> T where T: Decodable {
-            return try T(from: self.impl)
+            try T(from: self.impl)
         }
 
         @inline(__always) private func createTypeMismatchError(type: Any.Type, value: AttributeValue) -> DecodingError {
@@ -688,8 +684,7 @@ extension DynamoDB {
         }
 
         @inline(__always) private func decodeFixedWidthInteger<T: FixedWidthInteger>() throws
-            -> T
-        {
+            -> T {
             guard case .number(let number) = self.value else {
                 throw self.createTypeMismatchError(type: T.self, value: self.value)
             }
@@ -705,8 +700,7 @@ extension DynamoDB {
         }
 
         @inline(__always) private func decodeLosslessStringConvertible<T: LosslessStringConvertible>()
-            throws -> T
-        {
+            throws -> T {
             guard case .number(let number) = self.value else {
                 throw self.createTypeMismatchError(type: T.self, value: self.value)
             }
@@ -850,7 +844,7 @@ extension DynamoDB {
 
         mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws
             -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
-            return try self.impl.container(keyedBy: type)
+            try self.impl.container(keyedBy: type)
         }
 
         mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
@@ -869,8 +863,7 @@ extension DynamoDB {
         }
 
         @inline(__always) private mutating func decodeFixedWidthInteger<T: FixedWidthInteger>() throws
-            -> T
-        {
+            -> T {
             defer {
                 currentIndex += 1
                 if currentIndex == count {
@@ -891,8 +884,7 @@ extension DynamoDB {
         }
 
         @inline(__always) private mutating func decodeLosslessStringConvertible<T: LosslessStringConvertible>()
-            throws -> T
-        {
+            throws -> T {
             defer {
                 currentIndex += 1
                 if currentIndex == count {

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -79,31 +79,31 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
 }
 
 /// Implementation of  a`ByteBuffer` to `In` decoding
-public extension EventLoopLambdaHandler where In: Decodable {
-    func decode(buffer: ByteBuffer) throws -> In {
+extension EventLoopLambdaHandler where In: Decodable {
+    public func decode(buffer: ByteBuffer) throws -> In {
         try self.decoder.decode(In.self, from: buffer)
     }
 }
 
 /// Implementation of  `Out` to `ByteBuffer` encoding
-public extension EventLoopLambdaHandler where Out: Encodable {
-    func encode(allocator: ByteBufferAllocator, value: Out) throws -> ByteBuffer? {
+extension EventLoopLambdaHandler where Out: Encodable {
+    public func encode(allocator: ByteBufferAllocator, value: Out) throws -> ByteBuffer? {
         try self.encoder.encode(value, using: allocator)
     }
 }
 
 /// Default `ByteBuffer` to `In` decoder using Foundation's JSONDecoder
 /// Advanced users that want to inject their own codec can do it by overriding these functions.
-public extension EventLoopLambdaHandler where In: Decodable {
-    var decoder: LambdaCodableDecoder {
+extension EventLoopLambdaHandler where In: Decodable {
+    public var decoder: LambdaCodableDecoder {
         Lambda.defaultJSONDecoder
     }
 }
 
 /// Default `Out` to `ByteBuffer` encoder using Foundation's JSONEncoder
 /// Advanced users that want to inject their own codec can do it by overriding these functions.
-public extension EventLoopLambdaHandler where Out: Encodable {
-    var encoder: LambdaCodableEncoder {
+extension EventLoopLambdaHandler where Out: Encodable {
+    public var encoder: LambdaCodableEncoder {
         Lambda.defaultJSONEncoder
     }
 }
@@ -116,9 +116,9 @@ public protocol LambdaCodableEncoder {
     func encode<T: Encodable>(_ value: T, using allocator: ByteBufferAllocator) throws -> ByteBuffer
 }
 
-private extension Lambda {
-    static let defaultJSONDecoder = JSONDecoder()
-    static let defaultJSONEncoder = JSONEncoder()
+extension Lambda {
+    fileprivate static let defaultJSONDecoder = JSONDecoder()
+    fileprivate static let defaultJSONEncoder = JSONEncoder()
 }
 
 extension JSONDecoder: LambdaCodableDecoder {}

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -86,9 +86,9 @@ internal struct StringVoidClosureWrapper: LambdaHandler {
     }
 }
 
-public extension EventLoopLambdaHandler where In == String {
+extension EventLoopLambdaHandler where In == String {
     /// Implementation of a `ByteBuffer` to `String` decoding
-    func decode(buffer: ByteBuffer) throws -> String {
+    public func decode(buffer: ByteBuffer) throws -> String {
         var buffer = buffer
         guard let string = buffer.readString(length: buffer.readableBytes) else {
             fatalError("buffer.readString(length: buffer.readableBytes) failed")
@@ -97,9 +97,9 @@ public extension EventLoopLambdaHandler where In == String {
     }
 }
 
-public extension EventLoopLambdaHandler where Out == String {
+extension EventLoopLambdaHandler where Out == String {
     /// Implementation of `String` to `ByteBuffer` encoding
-    func encode(allocator: ByteBufferAllocator, value: String) throws -> ByteBuffer? {
+    public func encode(allocator: ByteBufferAllocator, value: String) throws -> ByteBuffer? {
         // FIXME: reusable buffer
         var buffer = allocator.buffer(capacity: value.utf8.count)
         buffer.writeString(value)

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -92,7 +92,8 @@ extension Lambda {
                       clientContext: String? = nil,
                       logger: Logger,
                       eventLoop: EventLoop,
-                      allocator: ByteBufferAllocator) {
+                      allocator: ByteBufferAllocator)
+        {
             self.requestID = requestID
             self.traceID = traceID
             self.invokedFunctionARN = invokedFunctionARN

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -100,8 +100,8 @@ extension Lambda {
     }
 }
 
-private extension Lambda.Context {
-    convenience init(logger: Logger, eventLoop: EventLoop, allocator: ByteBufferAllocator, invocation: Lambda.Invocation) {
+extension Lambda.Context {
+    fileprivate convenience init(logger: Logger, eventLoop: EventLoop, allocator: ByteBufferAllocator, invocation: Lambda.Invocation) {
         self.init(requestID: invocation.requestID,
                   traceID: invocation.traceID,
                   invokedFunctionARN: invocation.invokedFunctionARN,
@@ -144,8 +144,8 @@ extension EventLoopFuture {
     }
 }
 
-private extension Result {
-    var successful: Bool {
+extension Result {
+    private var successful: Bool {
         switch self {
         case .success:
             return true

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -126,8 +126,8 @@ extension Lambda {
     }
 }
 
-internal extension Lambda {
-    enum RuntimeError: Error {
+extension Lambda {
+    internal enum RuntimeError: Error {
         case badStatusCode(HTTPResponseStatus)
         case upstreamError(String)
         case invocationMissingHeader(String)
@@ -142,13 +142,13 @@ internal struct ErrorResponse: Codable {
     var errorMessage: String
 }
 
-internal extension ErrorResponse {
-    func toJSONBytes() -> [UInt8] {
+extension ErrorResponse {
+    internal func toJSONBytes() -> [UInt8] {
         var bytes = [UInt8]()
         bytes.append(UInt8(ascii: "{"))
-        bytes.append(contentsOf: #""errorType":"# .utf8)
+        bytes.append(contentsOf: #""errorType":"#.utf8)
         self.errorType.encodeAsJSONString(into: &bytes)
-        bytes.append(contentsOf: #","errorMessage":"# .utf8)
+        bytes.append(contentsOf: #","errorMessage":"#.utf8)
         self.errorMessage.encodeAsJSONString(into: &bytes)
         bytes.append(UInt8(ascii: "}"))
         return bytes
@@ -170,7 +170,8 @@ extension Lambda {
             }
 
             guard let deadline = headers.first(name: AmazonHeaders.deadline),
-                let unixTimeInMilliseconds = Int64(deadline) else {
+                  let unixTimeInMilliseconds = Int64(deadline)
+            else {
                 throw RuntimeError.invocationMissingHeader(AmazonHeaders.deadline)
             }
 

--- a/Sources/AWSLambdaRuntimeCore/Utils.swift
+++ b/Sources/AWSLambdaRuntimeCore/Utils.swift
@@ -58,15 +58,15 @@ internal enum Signal: Int32 {
     case TERM = 15
 }
 
-internal extension DispatchWallTime {
-    init(millisSinceEpoch: Int64) {
+extension DispatchWallTime {
+    internal init(millisSinceEpoch: Int64) {
         let nanoSinceEpoch = UInt64(millisSinceEpoch) * 1_000_000
         let seconds = UInt64(nanoSinceEpoch / 1_000_000_000)
         let nanoseconds = nanoSinceEpoch - (seconds * 1_000_000_000)
         self.init(timespec: timespec(tv_sec: Int(seconds), tv_nsec: Int(nanoseconds)))
     }
 
-    var millisSinceEpoch: Int64 {
+    internal var millisSinceEpoch: Int64 {
         Int64(bitPattern: self.rawValue) / -1_000_000
     }
 }

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -50,7 +50,8 @@ extension Lambda {
         public init(requestID: String = "\(DispatchTime.now().uptimeNanoseconds)",
                     traceID: String = "Root=\(DispatchTime.now().uptimeNanoseconds);Parent=\(DispatchTime.now().uptimeNanoseconds);Sampled=1",
                     invokedFunctionARN: String = "arn:aws:lambda:us-west-1:\(DispatchTime.now().uptimeNanoseconds):function:custom-runtime",
-                    timeout: DispatchTimeInterval = .seconds(5)) {
+                    timeout: DispatchTimeInterval = .seconds(5))
+        {
             self.requestID = requestID
             self.traceID = traceID
             self.invokedFunctionARN = invokedFunctionARN

--- a/Tests/AWSLambdaEventsTests/Utils/DateWrapperTests.swift
+++ b/Tests/AWSLambdaEventsTests/Utils/DateWrapperTests.swift
@@ -42,7 +42,7 @@ class DateWrapperTests: XCTestCase {
                 XCTFail("Unexpected error: \(error)"); return
             }
 
-            XCTAssertEqual(context.codingPath.compactMap { $0.stringValue }, ["date"])
+            XCTAssertEqual(context.codingPath.map(\.stringValue), ["date"])
             XCTAssertEqual(context.debugDescription, "Expected date to be in ISO8601 date format, but `\(date)` is not in the correct format")
             XCTAssertNil(context.underlyingError)
         }
@@ -74,7 +74,7 @@ class DateWrapperTests: XCTestCase {
                 XCTFail("Unexpected error: \(error)"); return
             }
 
-            XCTAssertEqual(context.codingPath.compactMap { $0.stringValue }, ["date"])
+            XCTAssertEqual(context.codingPath.map(\.stringValue), ["date"])
             XCTAssertEqual(context.debugDescription, "Expected date to be in ISO8601 date format with fractional seconds, but `\(date)` is not in the correct format")
             XCTAssertNil(context.underlyingError)
         }
@@ -132,7 +132,7 @@ class DateWrapperTests: XCTestCase {
                 XCTFail("Unexpected error: \(error)"); return
             }
 
-            XCTAssertEqual(context.codingPath.compactMap { $0.stringValue }, ["date"])
+            XCTAssertEqual(context.codingPath.map(\.stringValue), ["date"])
             XCTAssertEqual(context.debugDescription, "Expected date to be in RFC5322 date-time format with fractional seconds, but `\(date)` is not in the correct format")
             XCTAssertNil(context.underlyingError)
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
@@ -72,7 +72,7 @@ class LambdaLifecycleTest: XCTestCase {
         var count = 0
         let handler = CallbackLambdaHandler({ XCTFail("Should not be reached"); return $0.eventLoop.makeSucceededFuture($1) }) { context in
             count += 1
-            return context.eventLoop.makeSucceededFuture(Void())
+            return context.eventLoop.makeSucceededFuture(())
         }
 
         let eventLoop = eventLoopGroup.next()

--- a/Tests/AWSLambdaRuntimeCoreTests/MockLambdaServer.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/MockLambdaServer.swift
@@ -162,8 +162,8 @@ internal final class HTTPHandler: ChannelInboundHandler {
             }
         } else if request.head.uri.hasSuffix(Consts.postErrorURLSuffix) {
             guard let requestId = request.head.uri.split(separator: "/").dropFirst(3).first,
-                let json = requestBody,
-                let error = ErrorResponse.fromJson(json)
+                  let json = requestBody,
+                  let error = ErrorResponse.fromJson(json)
             else {
                 return self.writeResponse(context: context, status: .badRequest)
             }
@@ -245,8 +245,8 @@ internal enum ServerError: Error {
     case cantBind
 }
 
-private extension ErrorResponse {
-    static func fromJson(_ s: String) -> ErrorResponse? {
+extension ErrorResponse {
+    fileprivate static func fromJson(_ s: String) -> ErrorResponse? {
         let decoder = JSONDecoder()
         do {
             if let data = s.data(using: .utf8) {

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -81,8 +81,8 @@ struct TestError: Error, Equatable, CustomStringConvertible {
     }
 }
 
-internal extension Date {
-    var millisSinceEpoch: Int64 {
+extension Date {
+    internal var millisSinceEpoch: Int64 {
         Int64(self.timeIntervalSince1970 * 1000)
     }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swiftformat (until part of the toolchain)
 
-ARG swiftformat_version=0.44.6
+ARG swiftformat_version=0.47.3
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
 RUN cd $HOME/.tools/swift-format && swift build -c release
 RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat


### PR DESCRIPTION
### Motivation:

Our `swiftformat` should be more or less up to date. We should not require contributors to get a special version.

### Modifications:

- Update swiftformat from 0.44 to 0.47
- Bump swiftformat version to `5.2` (Since this is the swift version we require anyway)
- Add format option `--extensionacl on-declarations` to ensure ACL is never set on extensions
- Add format option `--disable typeSugar` to ensure `&&` is not replaced with `,`

### Result:

- Reduce the pain in contributing to `swift-aws-lambda-runtime`
