### PR TITLE
Inline and specialize LambdaHandlers

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -80,6 +80,7 @@ internal struct CodableVoidClosureWrapper<In: Decodable>: LambdaHandler {
 
 /// Implementation of  a`ByteBuffer` to `In` decoding
 extension EventLoopLambdaHandler where In: Decodable {
+    @inlinable
     public func decode(buffer: ByteBuffer) throws -> In {
         try self.decoder.decode(In.self, from: buffer)
     }
@@ -87,6 +88,7 @@ extension EventLoopLambdaHandler where In: Decodable {
 
 /// Implementation of  `Out` to `ByteBuffer` encoding
 extension EventLoopLambdaHandler where Out: Encodable {
+    @inlinable
     public func encode(allocator: ByteBufferAllocator, value: Out) throws -> ByteBuffer? {
         try self.encoder.encode(value, using: allocator)
     }

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -88,6 +88,7 @@ internal struct StringVoidClosureWrapper: LambdaHandler {
 
 extension EventLoopLambdaHandler where In == String {
     /// Implementation of a `ByteBuffer` to `String` decoding
+    @inlinable
     public func decode(buffer: ByteBuffer) throws -> String {
         var buffer = buffer
         guard let string = buffer.readString(length: buffer.readableBytes) else {
@@ -99,6 +100,7 @@ extension EventLoopLambdaHandler where In == String {
 
 extension EventLoopLambdaHandler where Out == String {
     /// Implementation of `String` to `ByteBuffer` encoding
+    @inlinable
     public func encode(allocator: ByteBufferAllocator, value: String) throws -> ByteBuffer? {
         // FIXME: reusable buffer
         var buffer = allocator.buffer(capacity: value.utf8.count)


### PR DESCRIPTION
Add `@inlinable` to default LambdaHandler implementations. This ensures that those implementations can be inlined into user code and can be specialized for their input and output types.

### Motivation:

We like speed.

### Modifications:

- Add @inlinable to default protocol implementations

### Result:

In my measurement I see another ~4% performance improvement.