### PR TITLE
update 5.4 to release docker image

### DIFF
--- a/docker/docker-compose.al2.54.yaml
+++ b/docker/docker-compose.al2.54.yaml
@@ -6,7 +6,7 @@ services:
     image: swift-aws-lambda:al2-5.4
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.4-amazonlinux2"
+        swift_version: "5.4"
 
   test:
     image: swift-aws-lambda:al2-5.4


### PR DESCRIPTION
motivation: 5.4 is out!

changes: use release docker images instead of nightly
