### PR TITLE
SNS MessageAttributes are optional

### DIFF
--- a/Sources/AWSLambdaEvents/SNS.swift
+++ b/Sources/AWSLambdaEvents/SNS.swift
@@ -49,7 +49,7 @@ public enum SNS {
         public let messageId: String
         public let type: String
         public let topicArn: String
-        public let messageAttributes: [String: Attribute]
+        public let messageAttributes: [String: Attribute]?
         public let signatureVersion: String
 
         @ISO8601WithFractionalSecondsCoding

--- a/Tests/AWSLambdaEventsTests/SNSTests.swift
+++ b/Tests/AWSLambdaEventsTests/SNSTests.swift
@@ -74,9 +74,9 @@ class SNSTests: XCTestCase {
         XCTAssertEqual(record.sns.signingCertURL, "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem")
         XCTAssertEqual(record.sns.unsubscribeUrl, "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:079477498937:EventSources-SNSTopic-1NHENSE2MQKF5:6fabdb7f-b27e-456d-8e8a-14679db9e40c")
 
-        XCTAssertEqual(record.sns.messageAttributes.count, 2)
+		XCTAssertEqual(record.sns.messageAttributes?.count, 2)
 
-        XCTAssertEqual(record.sns.messageAttributes["binary"], .binary([UInt8]("base64".utf8)))
-        XCTAssertEqual(record.sns.messageAttributes["string"], .string("abc123"))
+        XCTAssertEqual(record.sns.messageAttributes?["binary"], .binary([UInt8]("base64".utf8)))
+        XCTAssertEqual(record.sns.messageAttributes?["string"], .string("abc123"))
     }
 }

--- a/Tests/AWSLambdaEventsTests/SNSTests.swift
+++ b/Tests/AWSLambdaEventsTests/SNSTests.swift
@@ -74,7 +74,7 @@ class SNSTests: XCTestCase {
         XCTAssertEqual(record.sns.signingCertURL, "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem")
         XCTAssertEqual(record.sns.unsubscribeUrl, "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:079477498937:EventSources-SNSTopic-1NHENSE2MQKF5:6fabdb7f-b27e-456d-8e8a-14679db9e40c")
 
-		XCTAssertEqual(record.sns.messageAttributes?.count, 2)
+        XCTAssertEqual(record.sns.messageAttributes?.count, 2)
 
         XCTAssertEqual(record.sns.messageAttributes?["binary"], .binary([UInt8]("base64".utf8)))
         XCTAssertEqual(record.sns.messageAttributes?["string"], .string("abc123"))


### PR DESCRIPTION
Make MessageAttributes optional on SNS.Message

### Motivation:

When testing the following situation:
SNS Topic => SQS Queue  => Lambda

Notice that you'll see that SQS will have an SNS Message in the body without MessageAttributes

Note that after further research I also noticed that this is not sufficient:
- UnsubscribeUrl is transformed to UnsubscribeURL
- SigningCertUrl is transformed to SigningCertURL

### Modifications:

- Updated the unit tests
- Made MessageAttributes optional

### Result:

MessageAttributes will be optional, and you'll be able to parse an SNS Message in the situation described in the motivation