### PR TITLE
Fixes platform requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,9 @@ let package = Package(
         .library(name: "AWSLambdaTesting", targets: ["AWSLambdaTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.28.0")),
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.30.0")),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
+        .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.2.3")),
     ],
     targets: [
         .target(name: "AWSLambdaRuntime", dependencies: [

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -89,7 +89,7 @@ extension LambdaHandler {
 
 #if compiler(>=5.5)
 /// Strongly typed, processing protocol for a Lambda that takes a user defined `In` and returns a user defined `Out` async.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol AsyncLambdaHandler: EventLoopLambdaHandler {
     /// The Lambda initialization method
     /// Use this method to initialize resources that will be used in every request.
@@ -110,7 +110,7 @@ public protocol AsyncLambdaHandler: EventLoopLambdaHandler {
     func handle(event: In, context: Lambda.Context) async throws -> Out
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AsyncLambdaHandler {
     public func handle(context: Lambda.Context, event: In) -> EventLoopFuture<Out> {
         let promise = context.eventLoop.makePromise(of: Out.self)
@@ -121,7 +121,7 @@ extension AsyncLambdaHandler {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AsyncLambdaHandler {
     public static func main() {
         Lambda.run { context -> EventLoopFuture<ByteBufferLambdaHandler> in

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -83,7 +83,7 @@ class LambdaHandlerTest: XCTestCase {
 
     // MARK: - AsyncLambdaHandler
 
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testAsyncHandlerSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
         XCTAssertNoThrow(try server.start().wait())
@@ -106,7 +106,7 @@ class LambdaHandlerTest: XCTestCase {
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
 
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testVoidAsyncHandlerSuccess() {
         let server = MockLambdaServer(behavior: Behavior(result: .success(nil)))
         XCTAssertNoThrow(try server.start().wait())
@@ -127,7 +127,7 @@ class LambdaHandlerTest: XCTestCase {
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
 
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testAsyncHandlerFailure() {
         let server = MockLambdaServer(behavior: Behavior(result: .failure(TestError("boom"))))
         XCTAssertNoThrow(try server.start().wait())


### PR DESCRIPTION
### Motivation:

- For the 0.5.0 release we need to support the real platform requirements

### Modifications:

- Replace the wildcard platform requirements with `@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)` 
- Updated the dependencies: `swift-nio`, `swift-log` and `swift-backtrace`

### Result:

- Ready for `0.5.0`