### PR TITLE
Change Lambda.Context from class to struct

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -60,7 +60,7 @@ extension Lambda {
             var logger: Logger
             var eventLoop: EventLoop
             var allocator: ByteBufferAllocator
-            
+
             init(
                 requestID: String,
                 traceID: String,
@@ -83,46 +83,46 @@ extension Lambda {
                 self.allocator = allocator
             }
         }
-        
+
         private var storage: _Storage
-        
+
         /// The request ID, which identifies the request that triggered the function invocation.
         public var requestID: String {
             self.storage.requestID
         }
-        
+
         /// The AWS X-Ray tracing header.
         public var traceID: String {
             self.storage.traceID
         }
-        
+
         /// The ARN of the Lambda function, version, or alias that's specified in the invocation.
         public var invokedFunctionARN: String {
             self.storage.invokedFunctionARN
         }
-        
+
         /// The timestamp that the function times out
         public var deadline: DispatchWallTime {
             self.storage.deadline
         }
-        
+
         /// For invocations from the AWS Mobile SDK, data about the Amazon Cognito identity provider.
         public var cognitoIdentity: String? {
             self.storage.cognitoIdentity
         }
-        
+
         /// For invocations from the AWS Mobile SDK, data about the client application and device.
         public var clientContext: String? {
             self.storage.clientContext
         }
-        
+
         /// `Logger` to log with
         ///
         /// - note: The `LogLevel` can be configured using the `LOG_LEVEL` environment variable.
         public var logger: Logger {
             self.storage.logger
         }
-        
+
         /// The `EventLoop` the Lambda is executed on. Use this to schedule work with.
         /// This is useful when implementing the `EventLoopLambdaHandler` protocol.
         ///
@@ -131,13 +131,13 @@ extension Lambda {
         public var eventLoop: EventLoop {
             self.storage.eventLoop
         }
-        
+
         /// `ByteBufferAllocator` to allocate `ByteBuffer`
         /// This is useful when implementing `EventLoopLambdaHandler`
         public var allocator: ByteBufferAllocator {
             self.storage.allocator
         }
-        
+
         internal init(requestID: String,
                       traceID: String,
                       invokedFunctionARN: String,
@@ -155,8 +155,7 @@ extension Lambda {
                                     clientContext: clientContext,
                                     logger: logger,
                                     eventLoop: eventLoop,
-                                    allocator: allocator
-            )
+                                    allocator: allocator)
         }
 
         public func getRemainingTime() -> TimeAmount {

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -101,7 +101,7 @@ extension Lambda {
 }
 
 extension Lambda.Context {
-    fileprivate convenience init(logger: Logger, eventLoop: EventLoop, allocator: ByteBufferAllocator, invocation: Lambda.Invocation) {
+    init(logger: Logger, eventLoop: EventLoop, allocator: ByteBufferAllocator, invocation: Lambda.Invocation) {
         self.init(requestID: invocation.requestID,
                   traceID: invocation.traceID,
                   invokedFunctionARN: invocation.invokedFunctionARN,


### PR DESCRIPTION
_Lambda.Context changed from a class to a struct._

### Motivation:

As described in issue #215. Lambda.Context is currently a class that is a wrapper around values. Because it should be a value type, it was changed from a class to a struct.

### Modifications:

The modifications are nearly identical to the changes from #167 - minus the addition of Baggage. The change from a class to a struct also follows CoW semantics to keep performance high. Line 104 of Sources/AWSLambdaRuntimeCore/LambdaRunner.swift had "convenience" and "file private" removed as well.

There are two differences between #167 and this modification: 1) At the time of forking, Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift was not present. 2) There is no Baggage

### Result:

Lambda.Context is now a CoW-boxed struct instead of a class.

### Note:

_This is my first contribution. Please advise on how I can improve future contributions and the proper methodology on testing this change. Thank you all in advance :)_
