### PR TITLE
Clean up dependency graph and imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
+            .product(name: "NIO", package: "swift-nio"),
             .product(name: "_NIOConcurrency", package: "swift-nio"),
         ]),
         .testTarget(name: "AWSLambdaRuntimeCoreTests", dependencies: [
@@ -51,6 +52,7 @@ let package = Package(
         // for perf testing
         .target(name: "MockServer", dependencies: [
             .product(name: "NIOHTTP1", package: "swift-nio"),
+            .product(name: "NIO", package: "swift-nio"),
         ]),
         .target(name: "StringSample", dependencies: ["AWSLambdaRuntime"]),
         .target(name: "CodableSample", dependencies: ["AWSLambdaRuntime"]),

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _NIOConcurrency
 import Dispatch
 import NIO
 


### PR DESCRIPTION
Motivation:

AWSLambdaRuntimeCore and MockServer both have dependencies on the NIO
module, but they don't express this in their Package.swift: they
implicitly rely on these dependencies being met by the NIOHTTP1 import.
This was always brittle: it could lead to timing issues in the build
that could lead to it failing.

Modifications:

- Correctly express the dependency on NIO in Package.swift
- Correctly import _NIOConcurrency in files where it's used

Result:

Better and more accurate builds.
