### PR TITLE
Reorder Event and Context.

### DIFF
--- a/Examples/LambdaFunctions/Sources/Benchmark/main.swift
+++ b/Examples/LambdaFunctions/Sources/Benchmark/main.swift
@@ -25,7 +25,7 @@ struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture("hello, world!")
     }
 }

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -43,7 +43,7 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension LambdaHandler {
-    public func handle(context: Lambda.Context, event: In) -> EventLoopFuture<Out> {
+    public func handle(event: In, context: Lambda.Context) -> EventLoopFuture<Out> {
         let promise = context.eventLoop.makePromise(of: Out.self)
         promise.completeWithTask {
             try await self.handle(event: event, context: context)
@@ -82,7 +82,7 @@ public protocol EventLoopLambdaHandler: ByteBufferLambdaHandler {
     ///
     /// - Returns: An `EventLoopFuture` to report the result of the Lambda back to the runtime engine.
     ///            The `EventLoopFuture` should be completed with either a response of type `Out` or an `Error`
-    func handle(context: Lambda.Context, event: In) -> EventLoopFuture<Out>
+    func handle(event: In, context: Lambda.Context) -> EventLoopFuture<Out>
 
     /// Encode a response of type `Out` to `ByteBuffer`
     /// Concrete Lambda handlers implement this method to provide coding functionality.
@@ -106,7 +106,7 @@ public protocol EventLoopLambdaHandler: ByteBufferLambdaHandler {
 extension EventLoopLambdaHandler {
     /// Driver for `ByteBuffer` -> `In` decoding and `Out` -> `ByteBuffer` encoding
     @inlinable
-    public func handle(context: Lambda.Context, event: ByteBuffer) -> EventLoopFuture<ByteBuffer?> {
+    public func handle(event: ByteBuffer, context: Lambda.Context) -> EventLoopFuture<ByteBuffer?> {
         let input: In
         do {
             input = try self.decode(buffer: event)
@@ -114,7 +114,7 @@ extension EventLoopLambdaHandler {
             return context.eventLoop.makeFailedFuture(CodecError.requestDecoding(error))
         }
 
-        return self.handle(context: context, event: input).flatMapThrowing { output in
+        return self.handle(event: input, context: context).flatMapThrowing { output in
             do {
                 return try self.encode(allocator: context.allocator, value: output)
             } catch {
@@ -148,7 +148,7 @@ public protocol ByteBufferLambdaHandler {
     ///
     /// - Returns: An `EventLoopFuture` to report the result of the Lambda back to the runtime engine.
     ///            The `EventLoopFuture` should be completed with either a response encoded as `ByteBuffer` or an `Error`
-    func handle(context: Lambda.Context, event: ByteBuffer) -> EventLoopFuture<ByteBuffer?>
+    func handle(event: ByteBuffer, context: Lambda.Context) -> EventLoopFuture<ByteBuffer?>
 
     /// Clean up the Lambda resources asynchronously.
     /// Concrete Lambda handlers implement this method to shutdown resources like `HTTPClient`s and database connections.

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -70,7 +70,7 @@ extension Lambda {
                                       allocator: self.allocator,
                                       invocation: invocation)
                 logger.debug("sending invocation to lambda handler \(handler)")
-                return handler.handle(context: context, event: event)
+                return handler.handle(event: event, context: context)
                     // Hopping back to "our" EventLoop is important in case the handler returns a future that
                     // originiated from a foreign EventLoop/EventLoopGroup.
                     // This can happen if the handler uses a library (lets say a DB client) that manages its own threads/loops

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -97,7 +97,7 @@ extension Lambda {
         let handler = try promise.futureResult.wait()
 
         return try eventLoop.flatSubmit {
-            handler.handle(context: context, event: event)
+            handler.handle(event: event, context: context)
         }.wait()
     }
 }

--- a/Sources/CodableSample/main.swift
+++ b/Sources/CodableSample/main.swift
@@ -29,7 +29,7 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = Request
     typealias Out = Response
 
-    func handle(context: Lambda.Context, event: Request) -> EventLoopFuture<Response> {
+    func handle(event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
         // as an example, respond with the input event's reversed body
         context.eventLoop.makeSucceededFuture(Response(body: String(event.body.reversed())))
     }

--- a/Sources/StringSample/main.swift
+++ b/Sources/StringSample/main.swift
@@ -20,7 +20,7 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         // as an example, respond with the event's reversed body
         context.eventLoop.makeSucceededFuture(String(event.reversed()))
     }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -159,7 +159,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeSucceededFuture(event)
             }
         }
@@ -181,7 +181,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<Void> {
+            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
             }
         }
@@ -203,7 +203,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
@@ -19,7 +19,7 @@ struct EchoHandler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<String> {
+    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture(event)
     }
 }
@@ -34,7 +34,7 @@ struct FailedHandler: EventLoopLambdaHandler {
         self.reason = reason
     }
 
-    func handle(context: Lambda.Context, event: String) -> EventLoopFuture<Void> {
+    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
         context.eventLoop.makeFailedFuture(TestError(self.reason))
     }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
@@ -54,7 +54,7 @@ class LambdaLifecycleTest: XCTestCase {
             self.shutdown = shutdown
         }
 
-        func handle(context: Lambda.Context, event: ByteBuffer) -> EventLoopFuture<ByteBuffer?> {
+        func handle(event: ByteBuffer, context: Lambda.Context) -> EventLoopFuture<ByteBuffer?> {
             self.handler(context, event)
         }
 

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -43,7 +43,7 @@ class CodableLambdaTest: XCTestCase {
 
             let expected: Request
 
-            func handle(context: Lambda.Context, event: Request) -> EventLoopFuture<Void> {
+            func handle(event: Request, context: Lambda.Context) -> EventLoopFuture<Void> {
                 XCTAssertEqual(event, self.expected)
                 return context.eventLoop.makeSucceededVoidFuture()
             }
@@ -52,7 +52,7 @@ class CodableLambdaTest: XCTestCase {
         let handler = Handler(expected: request)
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try handler.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
         XCTAssertNil(outputBuffer)
     }
 
@@ -68,7 +68,7 @@ class CodableLambdaTest: XCTestCase {
 
             let expected: Request
 
-            func handle(context: Lambda.Context, event: Request) -> EventLoopFuture<Response> {
+            func handle(event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
                 XCTAssertEqual(event, self.expected)
                 return context.eventLoop.makeSucceededFuture(Response(requestId: event.requestId))
             }
@@ -77,7 +77,7 @@ class CodableLambdaTest: XCTestCase {
         let handler = Handler(expected: request)
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try handler.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
+        XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
         XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
         XCTAssertEqual(response?.requestId, request.requestId)
     }
@@ -107,7 +107,7 @@ class CodableLambdaTest: XCTestCase {
             handler.expected = request
 
             XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-            XCTAssertNoThrow(outputBuffer = try handler.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
+            XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
             XCTAssertNil(outputBuffer)
         }
     }
@@ -138,7 +138,7 @@ class CodableLambdaTest: XCTestCase {
             handler.expected = request
 
             XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-            XCTAssertNoThrow(outputBuffer = try handler.handle(context: self.newContext(), event: XCTUnwrap(inputBuffer)).wait())
+            XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
             XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
             XCTAssertEqual(response?.requestId, request.requestId)
         }


### PR DESCRIPTION
Fixes #89, for `ByteBufferLambdaHandler` and `EventLoopLambdaHandler` protocol.

In the new `LambdaHandler` protocol, the `event` already is in front of the `context`. Let's do the same for `ByteBufferLambdaHandler` and `EventLoopLambdaHandler`.