### PR TITLE
[RFC] Drop event label from handle methods in LambdaHandlers

### DIFF
--- a/Examples/LambdaFunctions/Sources/Benchmark/main.swift
+++ b/Examples/LambdaFunctions/Sources/Benchmark/main.swift
@@ -22,8 +22,8 @@ import NIO
 Lambda.run { $0.eventLoop.makeSucceededFuture(BenchmarkHandler()) }
 
 struct BenchmarkHandler: EventLoopLambdaHandler {
-    typealias In = String
-    typealias Out = String
+    typealias Event = String
+    typealias Output = String
 
     func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture("hello, world!")

--- a/Examples/LambdaFunctions/Sources/Benchmark/main.swift
+++ b/Examples/LambdaFunctions/Sources/Benchmark/main.swift
@@ -25,7 +25,7 @@ struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
+    func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture("hello, world!")
     }
 }

--- a/Examples/LambdaFunctions/Sources/CurrencyExchange/CurrencyExchangeHandler.swift
+++ b/Examples/LambdaFunctions/Sources/CurrencyExchange/CurrencyExchangeHandler.swift
@@ -35,7 +35,7 @@ struct CurrencyExchangeHandler: LambdaHandler {
         self.calculator = ExchangeRatesCalculator()
     }
 
-    func handle(event: Request, context: Lambda.Context) async throws -> [Exchange] {
+    func handle(_ event: Request, context: Lambda.Context) async throws -> [Exchange] {
         try await withCheckedThrowingContinuation { continuation in
             self.calculator.run(logger: context.logger) { result in
                 switch result {

--- a/Examples/LambdaFunctions/Sources/CurrencyExchange/CurrencyExchangeHandler.swift
+++ b/Examples/LambdaFunctions/Sources/CurrencyExchange/CurrencyExchangeHandler.swift
@@ -25,8 +25,8 @@ import Logging
 
 @main
 struct CurrencyExchangeHandler: LambdaHandler {
-    typealias In = Request
-    typealias Out = [Exchange]
+    typealias Event = Request
+    typealias Output = [Exchange]
 
     let calculator: ExchangeRatesCalculator
 

--- a/Examples/LambdaFunctions/Sources/ErrorHandling/ErrorsHappenHandler.swift
+++ b/Examples/LambdaFunctions/Sources/ErrorHandling/ErrorsHappenHandler.swift
@@ -18,8 +18,8 @@ import AWSLambdaRuntime
 
 @main
 struct ErrorsHappenHandler: LambdaHandler {
-    typealias In = Request
-    typealias Out = Response
+    typealias Event = Request
+    typealias Output = Response
 
     init(context: Lambda.InitializationContext) async throws {}
 

--- a/Examples/LambdaFunctions/Sources/ErrorHandling/ErrorsHappenHandler.swift
+++ b/Examples/LambdaFunctions/Sources/ErrorHandling/ErrorsHappenHandler.swift
@@ -23,7 +23,7 @@ struct ErrorsHappenHandler: LambdaHandler {
 
     init(context: Lambda.InitializationContext) async throws {}
 
-    func handle(event request: Request, context: Lambda.Context) async throws -> Response {
+    func handle(_ request: Request, context: Lambda.Context) async throws -> Response {
         // switch over the error type "requested" by the request, and trigger such error accordingly
         switch request.error {
         // no error here!

--- a/Examples/LambdaFunctions/Sources/HelloWorld/HelloWorldHandler.swift
+++ b/Examples/LambdaFunctions/Sources/HelloWorld/HelloWorldHandler.swift
@@ -17,8 +17,8 @@ import AWSLambdaRuntime
 // introductory example, the obligatory "hello, world!"
 @main
 struct HelloWorldHandler: LambdaHandler {
-    typealias In = String
-    typealias Out = String
+    typealias Event = String
+    typealias Output = String
 
     init(context: Lambda.InitializationContext) async throws {
         // setup your resources that you want to reuse here.

--- a/Examples/LambdaFunctions/Sources/HelloWorld/HelloWorldHandler.swift
+++ b/Examples/LambdaFunctions/Sources/HelloWorld/HelloWorldHandler.swift
@@ -24,7 +24,7 @@ struct HelloWorldHandler: LambdaHandler {
         // setup your resources that you want to reuse here.
     }
 
-    func handle(event: String, context: Lambda.Context) async throws -> String {
+    func handle(_ event: String, context: Lambda.Context) async throws -> String {
         "hello, world"
     }
 }

--- a/Examples/LocalDebugging/MyLambda/Sources/MyLambda/MyLambdaHandler.swift
+++ b/Examples/LocalDebugging/MyLambda/Sources/MyLambda/MyLambdaHandler.swift
@@ -26,7 +26,7 @@ struct MyLambdaHandler: LambdaHandler {
         // setup your resources that you want to reuse for every invocation here.
     }
 
-    func handle(event request: Request, context: Lambda.Context) async throws -> Response {
+    func handle(_ request: Request, context: Lambda.Context) async throws -> Response {
         // TODO: something useful
         Response(message: "Hello, \(request.name)!")
     }

--- a/Examples/LocalDebugging/MyLambda/Sources/MyLambda/MyLambdaHandler.swift
+++ b/Examples/LocalDebugging/MyLambda/Sources/MyLambda/MyLambdaHandler.swift
@@ -19,8 +19,8 @@ import Shared
 // a local server simulator which will allow local debugging
 @main
 struct MyLambdaHandler: LambdaHandler {
-    typealias In = Request
-    typealias Out = Response
+    typealias Event = Request
+    typealias Output = Response
 
     init(context: Lambda.InitializationContext) async throws {
         // setup your resources that you want to reuse for every invocation here.

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -21,33 +21,33 @@ import NIOFoundationCompat
 
 // MARK: - Codable support
 
-/// Implementation of  a`ByteBuffer` to `In` decoding
-extension EventLoopLambdaHandler where In: Decodable {
+/// Implementation of  a`ByteBuffer` to `Event` decoding
+extension EventLoopLambdaHandler where Event: Decodable {
     @inlinable
-    public func decode(buffer: ByteBuffer) throws -> In {
-        try self.decoder.decode(In.self, from: buffer)
+    public func decode(buffer: ByteBuffer) throws -> Event {
+        try self.decoder.decode(Event.self, from: buffer)
     }
 }
 
-/// Implementation of  `Out` to `ByteBuffer` encoding
-extension EventLoopLambdaHandler where Out: Encodable {
+/// Implementation of  `Output` to `ByteBuffer` encoding
+extension EventLoopLambdaHandler where Output: Encodable {
     @inlinable
-    public func encode(allocator: ByteBufferAllocator, value: Out) throws -> ByteBuffer? {
+    public func encode(allocator: ByteBufferAllocator, value: Output) throws -> ByteBuffer? {
         try self.encoder.encode(value, using: allocator)
     }
 }
 
-/// Default `ByteBuffer` to `In` decoder using Foundation's JSONDecoder
+/// Default `ByteBuffer` to `Event` decoder using Foundation's JSONDecoder
 /// Advanced users that want to inject their own codec can do it by overriding these functions.
-extension EventLoopLambdaHandler where In: Decodable {
+extension EventLoopLambdaHandler where Event: Decodable {
     public var decoder: LambdaCodableDecoder {
         Lambda.defaultJSONDecoder
     }
 }
 
-/// Default `Out` to `ByteBuffer` encoder using Foundation's JSONEncoder
+/// Default `Output` to `ByteBuffer` encoder using Foundation's JSONEncoder
 /// Advanced users that want to inject their own codec can do it by overriding these functions.
-extension EventLoopLambdaHandler where Out: Encodable {
+extension EventLoopLambdaHandler where Output: Encodable {
     public var encoder: LambdaCodableEncoder {
         Lambda.defaultJSONEncoder
     }

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-extension EventLoopLambdaHandler where In == String {
+extension EventLoopLambdaHandler where Event == String {
     /// Implementation of a `ByteBuffer` to `String` decoding
     @inlinable
     public func decode(buffer: ByteBuffer) throws -> String {
@@ -25,7 +25,7 @@ extension EventLoopLambdaHandler where In == String {
     }
 }
 
-extension EventLoopLambdaHandler where Out == String {
+extension EventLoopLambdaHandler where Output == String {
     /// Implementation of `String` to `ByteBuffer` encoding
     @inlinable
     public func encode(allocator: ByteBufferAllocator, value: String) throws -> ByteBuffer? {

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -62,7 +62,7 @@ extension Lambda {
             self.isGettingNextInvocation = true
             return self.runtimeClient.getNextInvocation(logger: logger).peekError { error in
                 logger.error("could not fetch work from lambda runtime engine: \(error)")
-            }.flatMap { invocation, event in
+            }.flatMap { invocation, bytes in
                 // 2. send invocation to handler
                 self.isGettingNextInvocation = false
                 let context = Context(logger: logger,
@@ -70,7 +70,7 @@ extension Lambda {
                                       allocator: self.allocator,
                                       invocation: invocation)
                 logger.debug("sending invocation to lambda handler \(handler)")
-                return handler.handle(event: event, context: context)
+                return handler.handle(bytes, context: context)
                     // Hopping back to "our" EventLoop is important in case the handler returns a future that
                     // originiated from a foreign EventLoop/EventLoopGroup.
                     // This can happen if the handler uses a library (lets say a DB client) that manages its own threads/loops

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -66,9 +66,9 @@ extension Lambda {
 
     public static func test<Handler: LambdaHandler>(
         _ handlerType: Handler.Type,
-        with event: Handler.In,
+        with event: Handler.Event,
         using config: TestConfig = .init()
-    ) throws -> Handler.Out {
+    ) throws -> Handler.Output {
         let logger = Logger(label: "test")
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -97,7 +97,7 @@ extension Lambda {
         let handler = try promise.futureResult.wait()
 
         return try eventLoop.flatSubmit {
-            handler.handle(event: event, context: context)
+            handler.handle(event, context: context)
         }.wait()
     }
 }

--- a/Sources/CodableSample/main.swift
+++ b/Sources/CodableSample/main.swift
@@ -26,8 +26,8 @@ struct Response: Codable {
 // in this example we are receiving and responding with codables. Request and Response above are examples of how to use
 // codables to model your reqeuest and response objects
 struct Handler: EventLoopLambdaHandler {
-    typealias In = Request
-    typealias Out = Response
+    typealias Event = Request
+    typealias Output = Response
 
     func handle(_ event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
         // as an example, respond with the input event's reversed body

--- a/Sources/CodableSample/main.swift
+++ b/Sources/CodableSample/main.swift
@@ -29,7 +29,7 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = Request
     typealias Out = Response
 
-    func handle(event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
+    func handle(_ event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
         // as an example, respond with the input event's reversed body
         context.eventLoop.makeSucceededFuture(Response(body: String(event.body.reversed())))
     }

--- a/Sources/StringSample/main.swift
+++ b/Sources/StringSample/main.swift
@@ -17,8 +17,8 @@ import NIOCore
 
 // in this example we are receiving and responding with strings
 struct Handler: EventLoopLambdaHandler {
-    typealias In = String
-    typealias Out = String
+    typealias Event = String
+    typealias Output = String
 
     func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         // as an example, respond with the event's reversed body

--- a/Sources/StringSample/main.swift
+++ b/Sources/StringSample/main.swift
@@ -20,7 +20,7 @@ struct Handler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
+    func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         // as an example, respond with the event's reversed body
         context.eventLoop.makeSucceededFuture(String(event.reversed()))
     }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -28,8 +28,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: LambdaHandler {
-            typealias In = String
-            typealias Out = String
+            typealias Event = String
+            typealias Output = String
 
             var initialized = false
 
@@ -57,8 +57,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: LambdaHandler {
-            typealias In = String
-            typealias Out = Void
+            typealias Event = String
+            typealias Output = Void
 
             var initialized = false
 
@@ -86,8 +86,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias In = String
-            typealias Out = String
+            typealias Event = String
+            typealias Output = String
 
             init(context: Lambda.InitializationContext) {}
 
@@ -109,8 +109,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias In = String
-            typealias Out = Void
+            typealias Event = String
+            typealias Output = Void
 
             init(context: Lambda.InitializationContext) {}
 
@@ -131,8 +131,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias In = String
-            typealias Out = String
+            typealias Event = String
+            typealias Output = String
 
             init(context: Lambda.InitializationContext) {}
 
@@ -156,8 +156,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = String
-            typealias Out = String
+            typealias Event = String
+            typealias Output = String
 
             func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeSucceededFuture(event)
@@ -178,8 +178,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = String
-            typealias Out = Void
+            typealias Event = String
+            typealias Output = Void
 
             func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
@@ -200,8 +200,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = String
-            typealias Out = String
+            typealias Event = String
+            typealias Output = String
 
             func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -39,7 +39,7 @@ class LambdaHandlerTest: XCTestCase {
                 self.initialized = true
             }
 
-            func handle(event: String, context: Lambda.Context) async throws -> String {
+            func handle(_ event: String, context: Lambda.Context) async throws -> String {
                 event
             }
         }
@@ -68,7 +68,7 @@ class LambdaHandlerTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(event: String, context: Lambda.Context) async throws {
+            func handle(_ event: String, context: Lambda.Context) async throws {
                 XCTFail("How can this be called if init failed")
             }
         }
@@ -91,7 +91,7 @@ class LambdaHandlerTest: XCTestCase {
 
             init(context: Lambda.InitializationContext) {}
 
-            func handle(event: String, context: Lambda.Context) async throws -> String {
+            func handle(_ event: String, context: Lambda.Context) async throws -> String {
                 event
             }
         }
@@ -114,7 +114,7 @@ class LambdaHandlerTest: XCTestCase {
 
             init(context: Lambda.InitializationContext) {}
 
-            func handle(event: String, context: Lambda.Context) async throws {}
+            func handle(_ event: String, context: Lambda.Context) async throws {}
         }
 
         let maxTimes = Int.random(in: 1 ... 10)
@@ -136,7 +136,7 @@ class LambdaHandlerTest: XCTestCase {
 
             init(context: Lambda.InitializationContext) {}
 
-            func handle(event: String, context: Lambda.Context) async throws -> String {
+            func handle(_ event: String, context: Lambda.Context) async throws -> String {
                 throw TestError("boom")
             }
         }
@@ -159,7 +159,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
+            func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeSucceededFuture(event)
             }
         }
@@ -181,7 +181,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = Void
 
-            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
+            func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
             }
         }
@@ -203,7 +203,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias In = String
             typealias Out = String
 
-            func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
+            func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
@@ -19,7 +19,7 @@ struct EchoHandler: EventLoopLambdaHandler {
     typealias In = String
     typealias Out = String
 
-    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<String> {
+    func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture(event)
     }
 }
@@ -34,7 +34,7 @@ struct FailedHandler: EventLoopLambdaHandler {
         self.reason = reason
     }
 
-    func handle(event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
+    func handle(_ event: String, context: Lambda.Context) -> EventLoopFuture<Void> {
         context.eventLoop.makeFailedFuture(TestError(self.reason))
     }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaLifecycleTest.swift
@@ -54,7 +54,7 @@ class LambdaLifecycleTest: XCTestCase {
             self.shutdown = shutdown
         }
 
-        func handle(event: ByteBuffer, context: Lambda.Context) -> EventLoopFuture<ByteBuffer?> {
+        func handle(_ event: ByteBuffer, context: Lambda.Context) -> EventLoopFuture<ByteBuffer?> {
             self.handler(context, event)
         }
 

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -43,7 +43,7 @@ class CodableLambdaTest: XCTestCase {
 
             let expected: Request
 
-            func handle(event: Request, context: Lambda.Context) -> EventLoopFuture<Void> {
+            func handle(_ event: Request, context: Lambda.Context) -> EventLoopFuture<Void> {
                 XCTAssertEqual(event, self.expected)
                 return context.eventLoop.makeSucceededVoidFuture()
             }
@@ -52,7 +52,7 @@ class CodableLambdaTest: XCTestCase {
         let handler = Handler(expected: request)
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
+        XCTAssertNoThrow(outputBuffer = try handler.handle(XCTUnwrap(inputBuffer), context: self.newContext()).wait())
         XCTAssertNil(outputBuffer)
     }
 
@@ -68,7 +68,7 @@ class CodableLambdaTest: XCTestCase {
 
             let expected: Request
 
-            func handle(event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
+            func handle(_ event: Request, context: Lambda.Context) -> EventLoopFuture<Response> {
                 XCTAssertEqual(event, self.expected)
                 return context.eventLoop.makeSucceededFuture(Response(requestId: event.requestId))
             }
@@ -77,7 +77,7 @@ class CodableLambdaTest: XCTestCase {
         let handler = Handler(expected: request)
 
         XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-        XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
+        XCTAssertNoThrow(outputBuffer = try handler.handle(XCTUnwrap(inputBuffer), context: self.newContext()).wait())
         XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
         XCTAssertEqual(response?.requestId, request.requestId)
     }
@@ -93,7 +93,7 @@ class CodableLambdaTest: XCTestCase {
 
             init(context: Lambda.InitializationContext) async throws {}
 
-            func handle(event: Request, context: Lambda.Context) async throws {
+            func handle(_ event: Request, context: Lambda.Context) async throws {
                 XCTAssertEqual(event, self.expected)
             }
         }
@@ -107,7 +107,7 @@ class CodableLambdaTest: XCTestCase {
             handler.expected = request
 
             XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-            XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
+            XCTAssertNoThrow(outputBuffer = try handler.handle(XCTUnwrap(inputBuffer), context: self.newContext()).wait())
             XCTAssertNil(outputBuffer)
         }
     }
@@ -122,7 +122,7 @@ class CodableLambdaTest: XCTestCase {
 
             init(context: Lambda.InitializationContext) async throws {}
 
-            func handle(event: Request, context: Lambda.Context) async throws -> Response {
+            func handle(_ event: Request, context: Lambda.Context) async throws -> Response {
                 XCTAssertEqual(event, self.expected)
                 return Response(requestId: event.requestId)
             }
@@ -138,7 +138,7 @@ class CodableLambdaTest: XCTestCase {
             handler.expected = request
 
             XCTAssertNoThrow(inputBuffer = try JSONEncoder().encode(request, using: self.allocator))
-            XCTAssertNoThrow(outputBuffer = try handler.handle(event: XCTUnwrap(inputBuffer), context: self.newContext()).wait())
+            XCTAssertNoThrow(outputBuffer = try handler.handle(XCTUnwrap(inputBuffer), context: self.newContext()).wait())
             XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
             XCTAssertEqual(response?.requestId, request.requestId)
         }

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -38,8 +38,8 @@ class CodableLambdaTest: XCTestCase {
         var outputBuffer: ByteBuffer?
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = Request
-            typealias Out = Void
+            typealias Event = Request
+            typealias Output = Void
 
             let expected: Request
 
@@ -63,8 +63,8 @@ class CodableLambdaTest: XCTestCase {
         var response: Response?
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias Event = Request
+            typealias Output = Response
 
             let expected: Request
 
@@ -86,8 +86,8 @@ class CodableLambdaTest: XCTestCase {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testCodableVoidHandler() {
         struct Handler: LambdaHandler {
-            typealias In = Request
-            typealias Out = Void
+            typealias Event = Request
+            typealias Output = Void
 
             var expected: Request?
 
@@ -115,8 +115,8 @@ class CodableLambdaTest: XCTestCase {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testCodableHandler() {
         struct Handler: LambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias Event = Request
+            typealias Output = Response
 
             var expected: Request?
 

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -30,8 +30,8 @@ class LambdaTestingTests: XCTestCase {
         }
 
         struct MyLambda: LambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias Event = Request
+            typealias Output = Response
 
             init(context: Lambda.InitializationContext) {}
 
@@ -54,8 +54,8 @@ class LambdaTestingTests: XCTestCase {
         }
 
         struct MyLambda: LambdaHandler {
-            typealias In = Request
-            typealias Out = Void
+            typealias Event = Request
+            typealias Output = Void
 
             init(context: Lambda.InitializationContext) {}
 
@@ -74,8 +74,8 @@ class LambdaTestingTests: XCTestCase {
         struct MyError: Error {}
 
         struct MyLambda: LambdaHandler {
-            typealias In = String
-            typealias Out = Void
+            typealias Event = String
+            typealias Output = Void
 
             init(context: Lambda.InitializationContext) {}
 
@@ -91,8 +91,8 @@ class LambdaTestingTests: XCTestCase {
 
     func testAsyncLongRunning() {
         struct MyLambda: LambdaHandler {
-            typealias In = String
-            typealias Out = String
+            typealias Event = String
+            typealias Output = String
 
             init(context: Lambda.InitializationContext) {}
 

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -35,7 +35,7 @@ class LambdaTestingTests: XCTestCase {
 
             init(context: Lambda.InitializationContext) {}
 
-            func handle(event: Request, context: Lambda.Context) async throws -> Response {
+            func handle(_ event: Request, context: Lambda.Context) async throws -> Response {
                 Response(message: "echo" + event.name)
             }
         }
@@ -59,7 +59,7 @@ class LambdaTestingTests: XCTestCase {
 
             init(context: Lambda.InitializationContext) {}
 
-            func handle(event: Request, context: Lambda.Context) async throws {
+            func handle(_ event: Request, context: Lambda.Context) async throws {
                 LambdaTestingTests.VoidLambdaHandlerInvokeCount += 1
             }
         }
@@ -79,7 +79,7 @@ class LambdaTestingTests: XCTestCase {
 
             init(context: Lambda.InitializationContext) {}
 
-            func handle(event: String, context: Lambda.Context) async throws {
+            func handle(_ event: String, context: Lambda.Context) async throws {
                 throw MyError()
             }
         }
@@ -96,7 +96,7 @@ class LambdaTestingTests: XCTestCase {
 
             init(context: Lambda.InitializationContext) {}
 
-            func handle(event: String, context: Lambda.Context) async throws -> String {
+            func handle(_ event: String, context: Lambda.Context) async throws -> String {
                 try await Task.sleep(nanoseconds: 500 * 1000 * 1000)
                 return event
             }


### PR DESCRIPTION
Drop event label from handle methods in LambdaHandlers protocols

### Motivation:

In Lambda functions user's handle events from different sources. Those events can be `S3Event`s, but also `APIGatewayRequest`s. Let's look at a Lambda, that integrates with APIGateway.

```swift
@main
struct EchoLambda: AsyncLambdaHandler {
    typealias Event = APIGatewayV2Request
    typealias Output = APIGatewayV2Response

    init(context: Lambda.InitializationContext) async throws {}

    func handle(event: APIGatewayV2Request, context: Lambda.Context) async throws -> APIGatewayV2Response {
        APIGatewayV2Response(statusCode: .ok, body: event.body)
    }
}
```

The argument in the `handle` method is labeled `event` even though, in this case `request` would be clearly a better name. The user could use `request` as a parameter name by explicitly specifying the parameter name:

```swift
func handle(event request: APIGatewayV2Request, context: Lambda.Context) async throws -> APIGatewayV2Response
```

However `event request` is not easy to read and the parameter name overwrite is not the most known swift feature. For this reason I would advice against this option.

For this reason I propose dropping the argument label and specifying a parameter name `event` to guide users. New function signature:

```swift
func handle(_ event: In, context: Lambda.Context) async throws -> Out
```

This would allow users to write lambdas, that integrate with APIGateway as such:

```swift
func handle(_ request: APIGatewayV2Request, context: Lambda.Context) async throws -> APIGatewayV2Response
```

### Modifications:

- Drop the `event` label in the `handle` LambdaHandler protocol methods
- Rename typealias in `EventLoopHandler` protocol to `Event` and `Output` (from `In` and `Out`)

### Result:

A cleaner, more flexible API.
