### PR TITLE
Use release version of 5.5 in CI

### DIFF
--- a/docker/docker-compose.al2.55.yaml
+++ b/docker/docker-compose.al2.55.yaml
@@ -6,7 +6,7 @@ services:
     image: swift-aws-lambda:al2-5.5
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.5-amazonlinux2"
+        swift_version: "5.5"
 
   test:
     image: swift-aws-lambda:al2-5.5


### PR DESCRIPTION
motivation: 5.5 release is available

changes: update docker CI setup to use the release version of 5.5

