### PR TITLE
Add guards for code that relies on _Concurrency to allow compilation with Xcode 13

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -88,7 +88,7 @@ extension LambdaHandler {
 
 // MARK: - AsyncLambdaHandler
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Strongly typed, processing protocol for a Lambda that takes a user defined `In` and returns a user defined `Out` async.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol AsyncLambdaHandler: EventLoopLambdaHandler {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -79,7 +79,7 @@ class LambdaHandlerTest: XCTestCase {
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
 
-    #if compiler(>=5.5)
+    #if compiler(>=5.5) && canImport(_Concurrency)
 
     // MARK: - AsyncLambdaHandler
 


### PR DESCRIPTION
Add extra code guards so that Xcode 13 will compile this package on macOS 11, which does not have symbols for Concurrency yet.

### Motivation:

Allow compilation with Xcode 13

### Modifications:

Changed code guards `#if compiler(>=5.5)` to `#if compiler(>=5.5) && canImport(_Concurrency)`

Got the idea from swift-server/swift-service-lifecycle#110

### Result:

Successfully compiles with Xcode 13
