### PR TITLE
Fix `Sendable` checking

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -23,6 +23,14 @@ import Logging
 import NIOCore
 import NIOPosix
 
+// Workaround for earlier Swift versions.
+// Remove and replace `LambdaSendable` with `Sendable` once we fully embrace concurrency.
+#if swift(>=5.5) && canImport(_Concurrency)
+public typealias LambdaSendable = Swift.Sendable
+#else
+public typealias LambdaSendable = Any
+#endif
+
 public enum Lambda {
     public typealias Handler = ByteBufferLambdaHandler
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -21,7 +21,7 @@ import NIOCore
 extension Lambda {
     /// Lambda runtime initialization context.
     /// The Lambda runtime generates and passes the `InitializationContext` to the Lambda factory as an argument.
-    public struct InitializationContext {
+    public struct InitializationContext: LambdaSendable {
         /// `Logger` to log with
         ///
         /// - note: The `LogLevel` can be configured using the `LOG_LEVEL` environment variable.
@@ -60,7 +60,7 @@ extension Lambda {
 
 /// Lambda runtime context.
 /// The Lambda runtime generates and passes the `Context` to the Lambda handler as an argument.
-public struct LambdaContext: CustomDebugStringConvertible {
+public struct LambdaContext: CustomDebugStringConvertible, LambdaSendable {
     final class _Storage {
         var requestID: String
         var traceID: String

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -20,7 +20,7 @@ import NIOCore
 #if compiler(>=5.5) && canImport(_Concurrency)
 /// Strongly typed, processing protocol for a Lambda that takes a user defined `Event` and returns a user defined `Output` async.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public protocol LambdaHandler: EventLoopLambdaHandler {
+public protocol LambdaHandler: EventLoopLambdaHandler, Sendable {
     /// The Lambda initialization method
     /// Use this method to initialize resources that will be used in every request.
     ///
@@ -69,7 +69,7 @@ extension LambdaHandler {
 ///         The `EventLoopLambdaHandler` will execute the Lambda on the same `EventLoop` as the core runtime engine, making the processing faster but requires
 ///         more care from the implementation to never block the `EventLoop`.
 public protocol EventLoopLambdaHandler: ByteBufferLambdaHandler {
-    associatedtype Event
+    associatedtype Event: LambdaSendable
     associatedtype Output
 
     /// The Lambda handling method


### PR DESCRIPTION
Current state:

```
Sources/AWSLambdaRuntimeCore/LambdaContext.swift:28:20: error: stored property 'logger' of 'Sendable'-conforming struct 'InitializationContext' has non-sendable type 'Logger'
        public let logger: Logger
                   ^
Sources/AWSLambdaRuntimeCore/LambdaContext.swift:34:20: error: stored property 'eventLoop' of 'Sendable'-conforming struct 'InitializationContext' has non-sendable type 'EventLoop'
        public let eventLoop: EventLoop
                   ^
Sources/AWSLambdaRuntimeCore/LambdaContext.swift:37:20: error: stored property 'allocator' of 'Sendable'-conforming struct 'InitializationContext' has non-sendable type 'ByteBufferAllocator'
        public let allocator: ByteBufferAllocator
                   ^
Sources/AWSLambdaRuntimeCore/LambdaContext.swift:98:17: error: stored property 'storage' of 'Sendable'-conforming struct 'LambdaContext' has non-sendable type 'LambdaContext._Storage'
    private var storage: _Storage
                ^
```

We’re waiting for `SwiftNIO` and `SwiftLog` to fully support `Sendable`, meanwhile the design of `LambdaContext` should be adapted for `Sendable`.

----

WIP: Fix `Sendable` checking to pass nightly CI.

### Motivation:

Add necessary `Sendable` conformance according to Swift Concurrency adoption guidelines for Swift Server Libraries (swift-server/guides#70).

### Modifications:

- Introduce `LambdaSendable` as a drop-in `Sendable` replacement that's compatible with prior Swift versions;
- Conform `LambdaHandler` to `Sendable`;
- Conform `LambdaContext` and `Lambda.InitializationContext` to `LambdaSendable`;
- Require `EventLoopLambdaHandler.Event` and `EventLoopLambdaHandler.Output` to conform to `LambdaSendable`.