### PR TITLE
Lambda factory as a protocol requirement.

### DIFF
--- a/Examples/Benchmark/BenchmarkHandler.swift
+++ b/Examples/Benchmark/BenchmarkHandler.swift
@@ -25,7 +25,7 @@ struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
 
-    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
+    static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
         context.eventLoop.makeSucceededFuture(BenchmarkHandler())
     }
 

--- a/Examples/Benchmark/BenchmarkHandler.swift
+++ b/Examples/Benchmark/BenchmarkHandler.swift
@@ -13,20 +13,23 @@
 //===----------------------------------------------------------------------===//
 
 import AWSLambdaRuntimeCore
-import NIO
+import NIOCore
 
 // If you would like to benchmark Swift's Lambda Runtime,
 // use this example which is more performant.
 // `EventLoopLambdaHandler` does not offload the Lambda processing to a separate thread
 // while the closure-based handlers do.
 
+@main
 struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
+
+    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
+        context.eventLoop.makeSucceededFuture(BenchmarkHandler())
+    }
 
     func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture("hello, world!")
     }
 }
-
-Lambda.run { $0.eventLoop.makeSucceededFuture(BenchmarkHandler()) }

--- a/Examples/Deployment/Sources/Benchmark/BenchmarkHandler.swift
+++ b/Examples/Deployment/Sources/Benchmark/BenchmarkHandler.swift
@@ -13,20 +13,23 @@
 //===----------------------------------------------------------------------===//
 
 import AWSLambdaRuntimeCore
-import NIOCore
+import NIO
 
 // If you would like to benchmark Swift's Lambda Runtime,
 // use this example which is more performant.
 // `EventLoopLambdaHandler` does not offload the Lambda processing to a separate thread
 // while the closure-based handlers do.
 
-struct MyLambda: EventLoopLambdaHandler {
+@main
+struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
+
+    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
+        context.eventLoop.makeSucceededFuture(BenchmarkHandler())
+    }
 
     func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture("hello, world!")
     }
 }
-
-Lambda.run { $0.eventLoop.makeSucceededFuture(MyLambda()) }

--- a/Examples/Deployment/Sources/Benchmark/BenchmarkHandler.swift
+++ b/Examples/Deployment/Sources/Benchmark/BenchmarkHandler.swift
@@ -25,7 +25,7 @@ struct BenchmarkHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
 
-    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
+    static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
         context.eventLoop.makeSucceededFuture(BenchmarkHandler())
     }
 

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -34,13 +34,17 @@ public enum Lambda {
 
     /// Run a Lambda defined by implementing the ``ByteBufferLambdaHandler`` protocol.
     /// The Runtime will manage the Lambdas application lifecycle automatically. It will invoke the
-    /// ``ByteBufferLambdaHandler/factory(context:)`` to create a new Handler.
+    /// ``ByteBufferLambdaHandler/makeHandler(context:)`` to create a new Handler.
     ///
     /// - parameters:
-    ///     - factory: A `ByteBufferLambdaHandler` factory.
+    ///     - configuration: A Lambda runtime configuration object
+    ///     - handlerType: The Handler to create and invoke.
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
-    internal static func run<Handler: ByteBufferLambdaHandler>(configuration: Configuration = .init(), handlerType: Handler.Type) -> Result<Int, Error> {
+    internal static func run<Handler: ByteBufferLambdaHandler>(
+        configuration: Configuration = .init(),
+        handlerType: Handler.Type
+    ) -> Result<Int, Error> {
         let _run = { (configuration: Configuration) -> Result<Int, Error> in
             Backtrace.install()
             var logger = Logger(label: "Lambda")
@@ -89,7 +93,7 @@ public enum Lambda {
             return _run(configuration)
         }
         #else
-        return _run(configuration, factory)
+        return _run(configuration)
         #endif
     }
 }

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -24,27 +24,6 @@ import NIOCore
 import NIOPosix
 
 public enum Lambda {
-    public typealias Handler = ByteBufferLambdaHandler
-
-    /// `ByteBufferLambdaHandler` factory.
-    ///
-    /// A function that takes a `InitializationContext` and returns an `EventLoopFuture` of a `ByteBufferLambdaHandler`
-    public typealias HandlerFactory = (InitializationContext) -> EventLoopFuture<Handler>
-
-    /// Run a Lambda defined by implementing the `LambdaHandler` protocol provided via a `LambdaHandlerFactory`.
-    /// Use this to initialize all your resources that you want to cache between invocations. This could be database connections and HTTP clients for example.
-    /// It is encouraged to use the given `EventLoop`'s conformance to `EventLoopGroup` when initializing NIO dependencies. This will improve overall performance.
-    ///
-    /// - parameters:
-    ///     - factory: A `ByteBufferLambdaHandler` factory.
-    ///
-    /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
-    public static func run(_ factory: @escaping HandlerFactory) {
-        if case .failure(let error) = self.run(factory: factory) {
-            fatalError("\(error)")
-        }
-    }
-
     /// Utility to access/read environment variables
     public static func env(_ name: String) -> String? {
         guard let value = getenv(name) else {
@@ -53,30 +32,23 @@ public enum Lambda {
         return String(cString: value)
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    // for testing and internal use
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    internal static func run<Handler: LambdaHandler>(configuration: Configuration = .init(), handlerType: Handler.Type) -> Result<Int, Error> {
-        self.run(configuration: configuration, factory: { context -> EventLoopFuture<ByteBufferLambdaHandler> in
-            let promise = context.eventLoop.makePromise(of: ByteBufferLambdaHandler.self)
-            promise.completeWithTask {
-                try await Handler(context: context)
-            }
-            return promise.futureResult
-        })
-    }
-    #endif
-
-    // for testing and internal use
-    internal static func run(configuration: Configuration = .init(), factory: @escaping HandlerFactory) -> Result<Int, Error> {
-        let _run = { (configuration: Configuration, factory: @escaping HandlerFactory) -> Result<Int, Error> in
+    /// Run a Lambda defined by implementing the ``ByteBufferLambdaHandler`` protocol.
+    /// The Runtime will manage the Lambdas application lifecycle automatically. It will invoke the
+    /// ``ByteBufferLambdaHandler/factory(context:)`` to create a new Handler.
+    ///
+    /// - parameters:
+    ///     - factory: A `ByteBufferLambdaHandler` factory.
+    ///
+    /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
+    internal static func run<Handler: ByteBufferLambdaHandler>(configuration: Configuration = .init(), handlerType: Handler.Type) -> Result<Int, Error> {
+        let _run = { (configuration: Configuration) -> Result<Int, Error> in
             Backtrace.install()
             var logger = Logger(label: "Lambda")
             logger.logLevel = configuration.general.logLevel
 
             var result: Result<Int, Error>!
             MultiThreadedEventLoopGroup.withCurrentThreadAsEventLoop { eventLoop in
-                let runtime = LambdaRuntime(eventLoop: eventLoop, logger: logger, configuration: configuration, factory: factory)
+                let runtime = LambdaRuntime<Handler>(eventLoop: eventLoop, logger: logger, configuration: configuration)
                 #if DEBUG
                 let signalSource = trap(signal: configuration.lifecycle.stopSignal) { signal in
                     logger.info("intercepted signal: \(signal)")
@@ -108,13 +80,13 @@ public enum Lambda {
         if Lambda.env("LOCAL_LAMBDA_SERVER_ENABLED").flatMap(Bool.init) ?? false {
             do {
                 return try Lambda.withLocalServer {
-                    _run(configuration, factory)
+                    _run(configuration)
                 }
             } catch {
                 return .failure(error)
             }
         } else {
-            return _run(configuration, factory)
+            return _run(configuration)
         }
         #else
         return _run(configuration, factory)

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -20,7 +20,9 @@ import NIOCore
 
 extension Lambda {
     /// Lambda runtime initialization context.
-    /// The Lambda runtime generates and passes the `InitializationContext` to the Lambda factory as an argument.
+    /// The Lambda runtime generates and passes the `InitializationContext` to the Handlers
+    /// ``ByteBufferLambdaHandler/makeHandler(context:)`` or ``LambdaHandler/init(context:)``
+    /// as an argument.
     public struct InitializationContext {
         /// `Logger` to log with
         ///

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -51,11 +51,11 @@ extension LambdaHandler {
     public static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
         let promise = context.eventLoop.makePromise(of: Self.self)
         promise.completeWithTask {
-            try await Self.init(context: context)
+            try await Self(context: context)
         }
         return promise.futureResult
     }
-    
+
     public func handle(_ event: Event, context: LambdaContext) -> EventLoopFuture<Output> {
         let promise = context.eventLoop.makePromise(of: Output.self)
         promise.completeWithTask {
@@ -84,7 +84,6 @@ extension LambdaHandler {
 ///         implementation to never block the `EventLoop`. Implement this protocol only in performance
 ///         critical situations and implement ``LambdaHandler`` in all other circumstances.
 public protocol EventLoopLambdaHandler: ByteBufferLambdaHandler {
-    
     /// The lambda functions input. In most cases this should be Codable. If your event originates from an
     /// AWS service, have a look at [AWSLambdaEvents](https://github.com/swift-server/swift-aws-lambda-events),
     /// which provides a number of commonly used AWS Event implementations.
@@ -159,7 +158,6 @@ extension EventLoopLambdaHandler where Output == Void {
 ///         ``LambdaHandler`` based APIs.
 ///         Most users are not expected to use this protocol.
 public protocol ByteBufferLambdaHandler {
-    
     /// Create your Lambda handler for the runtime.
     ///
     /// Use this to initialize all your resources that you want to cache between invocations. This could be database
@@ -167,7 +165,7 @@ public protocol ByteBufferLambdaHandler {
     /// to `EventLoopGroup` when initializing NIO dependencies. This will improve overall performance, as it
     /// minimizes thread hopping.
     static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self>
-    
+
     /// The Lambda handling method
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///
@@ -194,7 +192,6 @@ extension ByteBufferLambdaHandler {
 }
 
 extension ByteBufferLambdaHandler {
-    
     /// Initializes and runs the lambda function.
     ///
     /// If you precede your ``ByteBufferLambdaHandler`` conformer's declaration with the

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -48,7 +48,7 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension LambdaHandler {
-    public static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
+    public static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Self> {
         let promise = context.eventLoop.makePromise(of: Self.self)
         promise.completeWithTask {
             try await Self(context: context)
@@ -164,7 +164,7 @@ public protocol ByteBufferLambdaHandler {
     /// connections and HTTP clients for example. It is encouraged to use the given `EventLoop`'s conformance
     /// to `EventLoopGroup` when initializing NIO dependencies. This will improve overall performance, as it
     /// minimizes thread hopping.
-    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Self>
+    static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Self>
 
     /// The Lambda handling method
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -34,14 +34,14 @@ extension Lambda {
         /// Run the user provided initializer. This *must* only be called once.
         ///
         /// - Returns: An `EventLoopFuture<LambdaHandler>` fulfilled with the outcome of the initialization.
-        func initialize(logger: Logger, factory: @escaping HandlerFactory) -> EventLoopFuture<Handler> {
+        func initialize<Handler: ByteBufferLambdaHandler>(logger: Logger, handlerType: Handler.Type) -> EventLoopFuture<Handler> {
             logger.debug("initializing lambda")
             // 1. create the handler from the factory
             // 2. report initialization error if one occured
             let context = InitializationContext(logger: logger,
                                                 eventLoop: self.eventLoop,
                                                 allocator: self.allocator)
-            return factory(context)
+            return Handler.factory(context: context)
                 // Hopping back to "our" EventLoop is important in case the factory returns a future
                 // that originated from a foreign EventLoop/EventLoopGroup.
                 // This can happen if the factory uses a library (let's say a database client) that manages its own threads/loops
@@ -56,7 +56,7 @@ extension Lambda {
                 }
         }
 
-        func run(logger: Logger, handler: Handler) -> EventLoopFuture<Void> {
+        func run<Handler: ByteBufferLambdaHandler>(logger: Logger, handler: Handler) -> EventLoopFuture<Void> {
             logger.debug("lambda invocation sequence starting")
             // 1. request invocation from lambda runtime engine
             self.isGettingNextInvocation = true

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -41,7 +41,7 @@ extension Lambda {
             let context = InitializationContext(logger: logger,
                                                 eventLoop: self.eventLoop,
                                                 allocator: self.allocator)
-            return Handler.factory(context: context)
+            return Handler.makeHandler(context: context)
                 // Hopping back to "our" EventLoop is important in case the factory returns a future
                 // that originated from a foreign EventLoop/EventLoopGroup.
                 // This can happen if the factory uses a library (let's say a database client) that manages its own threads/loops

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -37,7 +37,6 @@ public final class LambdaRuntime<Handler: ByteBufferLambdaHandler> {
     /// - parameters:
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
-    ///     - factory: A `LambdaHandlerFactory` to create the concrete  Lambda handler.
     public convenience init(eventLoop: EventLoop, logger: Logger) {
         self.init(eventLoop: eventLoop, logger: logger, configuration: .init())
     }

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -19,12 +19,11 @@ import NIOCore
 /// `LambdaRuntime` manages the Lambda process lifecycle.
 ///
 /// - note: It is intended to be used within a single `EventLoop`. For this reason this class is not thread safe.
-public final class LambdaRuntime {
+public final class LambdaRuntime<Handler: ByteBufferLambdaHandler> {
     private let eventLoop: EventLoop
     private let shutdownPromise: EventLoopPromise<Int>
     private let logger: Logger
     private let configuration: Lambda.Configuration
-    private let factory: Lambda.HandlerFactory
 
     private var state = State.idle {
         willSet {
@@ -39,16 +38,15 @@ public final class LambdaRuntime {
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
     ///     - factory: A `LambdaHandlerFactory` to create the concrete  Lambda handler.
-    public convenience init(eventLoop: EventLoop, logger: Logger, factory: @escaping Lambda.HandlerFactory) {
-        self.init(eventLoop: eventLoop, logger: logger, configuration: .init(), factory: factory)
+    public convenience init(eventLoop: EventLoop, logger: Logger) {
+        self.init(eventLoop: eventLoop, logger: logger, configuration: .init())
     }
 
-    init(eventLoop: EventLoop, logger: Logger, configuration: Lambda.Configuration, factory: @escaping Lambda.HandlerFactory) {
+    init(eventLoop: EventLoop, logger: Logger, configuration: Lambda.Configuration) {
         self.eventLoop = eventLoop
         self.shutdownPromise = eventLoop.makePromise(of: Int.self)
         self.logger = logger
         self.configuration = configuration
-        self.factory = factory
     }
 
     deinit {
@@ -79,8 +77,8 @@ public final class LambdaRuntime {
         logger[metadataKey: "lifecycleId"] = .string(self.configuration.lifecycle.id)
         let runner = Lambda.Runner(eventLoop: self.eventLoop, configuration: self.configuration)
 
-        let startupFuture = runner.initialize(logger: logger, factory: self.factory)
-        startupFuture.flatMap { handler -> EventLoopFuture<(ByteBufferLambdaHandler, Result<Int, Error>)> in
+        let startupFuture = runner.initialize(logger: logger, handlerType: Handler.self)
+        startupFuture.flatMap { handler -> EventLoopFuture<(Handler, Result<Int, Error>)> in
             // after the startup future has succeeded, we have a handler that we can use
             // to `run` the lambda.
             let finishedPromise = self.eventLoop.makePromise(of: Int.self)
@@ -173,7 +171,7 @@ public final class LambdaRuntime {
     private enum State {
         case idle
         case initializing
-        case active(Lambda.Runner, Lambda.Handler)
+        case active(Lambda.Runner, Handler)
         case shuttingdown
         case shutdown
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -86,7 +86,7 @@ public final class LambdaRuntime<Handler: ByteBufferLambdaHandler> {
             self.run(promise: finishedPromise)
             return finishedPromise.futureResult.mapResult { (handler, $0) }
         }
-        .flatMap { (handler, runnerResult) -> EventLoopFuture<Int> in
+        .flatMap { handler, runnerResult -> EventLoopFuture<Int> in
             // after the lambda finishPromise has succeeded or failed we need to
             // shutdown the handler
             let shutdownContext = Lambda.ShutdownContext(logger: logger, eventLoop: self.eventLoop)
@@ -95,7 +95,7 @@ public final class LambdaRuntime<Handler: ByteBufferLambdaHandler> {
                 // the runner result
                 logger.error("Error shutting down handler: \(error)")
                 throw Lambda.RuntimeError.shutdownError(shutdownError: error, runnerResult: runnerResult)
-            }.flatMapResult { (_) -> Result<Int, Error> in
+            }.flatMapResult { _ -> Result<Int, Error> in
                 // we had no error shutting down the lambda. let's return the runner's result
                 runnerResult
             }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -159,7 +159,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias Event = String
             typealias Output = String
 
-            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+            static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
@@ -183,7 +183,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias Event = String
             typealias Output = Void
 
-            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+            static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
@@ -207,7 +207,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias Event = String
             typealias Output = String
 
-            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+            static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
@@ -231,7 +231,7 @@ class LambdaHandlerTest: XCTestCase {
             typealias Event = String
             typealias Output = String
 
-            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+            static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeFailedFuture(TestError("kaboom"))
             }
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -158,7 +158,7 @@ class LambdaHandlerTest: XCTestCase {
         struct Handler: EventLoopLambdaHandler {
             typealias Event = String
             typealias Output = String
-            
+
             static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
@@ -182,7 +182,7 @@ class LambdaHandlerTest: XCTestCase {
         struct Handler: EventLoopLambdaHandler {
             typealias Event = String
             typealias Output = Void
-            
+
             static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
@@ -206,7 +206,7 @@ class LambdaHandlerTest: XCTestCase {
         struct Handler: EventLoopLambdaHandler {
             typealias Event = String
             typealias Output = String
-            
+
             static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
@@ -226,11 +226,11 @@ class LambdaHandlerTest: XCTestCase {
         let server = MockLambdaServer(behavior: FailedBootstrapBehavior())
         XCTAssertNoThrow(try server.start().wait())
         defer { XCTAssertNoThrow(try server.stop().wait()) }
-        
+
         struct Handler: EventLoopLambdaHandler {
             typealias Event = String
             typealias Output = String
-            
+
             static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeFailedFuture(TestError("kaboom"))
             }
@@ -240,7 +240,7 @@ class LambdaHandlerTest: XCTestCase {
                 return context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }
-        
+
         let result = Lambda.run(configuration: .init(), handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldFailWithError: TestError("kaboom"))
     }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
@@ -20,7 +20,7 @@ struct EchoHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
 
-    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<EchoHandler> {
+    static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<EchoHandler> {
         context.eventLoop.makeSucceededFuture(EchoHandler())
     }
 
@@ -35,7 +35,7 @@ struct StartupErrorHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
 
-    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<StartupErrorHandler> {
+    static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<StartupErrorHandler> {
         context.eventLoop.makeFailedFuture(StartupError())
     }
 
@@ -51,7 +51,7 @@ struct RuntimeErrorHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = Void
 
-    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<RuntimeErrorHandler> {
+    static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<RuntimeErrorHandler> {
         context.eventLoop.makeSucceededFuture(RuntimeErrorHandler())
     }
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
@@ -19,7 +19,7 @@ import XCTest
 struct EchoHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
-    
+
     static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<EchoHandler> {
         context.eventLoop.makeSucceededFuture(EchoHandler())
     }
@@ -34,7 +34,7 @@ struct StartupError: Error {}
 struct StartupErrorHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
-    
+
     static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<StartupErrorHandler> {
         context.eventLoop.makeFailedFuture(StartupError())
     }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
@@ -14,27 +14,48 @@
 
 import AWSLambdaRuntimeCore
 import NIOCore
+import XCTest
 
 struct EchoHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = String
+    
+    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<EchoHandler> {
+        context.eventLoop.makeSucceededFuture(EchoHandler())
+    }
 
     func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture(event)
     }
 }
 
-struct FailedHandler: EventLoopLambdaHandler {
+struct StartupError: Error {}
+
+struct StartupErrorHandler: EventLoopLambdaHandler {
+    typealias Event = String
+    typealias Output = String
+    
+    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<StartupErrorHandler> {
+        context.eventLoop.makeFailedFuture(StartupError())
+    }
+
+    func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
+        XCTFail("Must never be called")
+        return context.eventLoop.makeSucceededFuture(event)
+    }
+}
+
+struct RuntimeError: Error {}
+
+struct RuntimeErrorHandler: EventLoopLambdaHandler {
     typealias Event = String
     typealias Output = Void
 
-    private let reason: String
-
-    init(_ reason: String) {
-        self.reason = reason
+    static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<RuntimeErrorHandler> {
+        context.eventLoop.makeSucceededFuture(RuntimeErrorHandler())
     }
 
     func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<Void> {
-        context.eventLoop.makeFailedFuture(TestError(self.reason))
+        context.eventLoop.makeFailedFuture(RuntimeError())
     }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
@@ -40,12 +40,11 @@ class LambdaRunnerTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handler: EchoHandler()))
+        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handlerType: EchoHandler.self))
     }
 
     func testFailure() {
         struct Behavior: LambdaServerBehavior {
-            static let error = "boom"
             let requestId = UUID().uuidString
             func getInvocation() -> GetInvocationResult {
                 .success((requestId: self.requestId, event: "hello"))
@@ -58,7 +57,7 @@ class LambdaRunnerTest: XCTestCase {
 
             func processError(requestId: String, error: ErrorResponse) -> Result<Void, ProcessErrorError> {
                 XCTAssertEqual(self.requestId, requestId, "expecting requestId to match")
-                XCTAssertEqual(Behavior.error, error.errorMessage, "expecting error to match")
+                XCTAssertEqual(String(describing: RuntimeError()), error.errorMessage, "expecting error to match")
                 return .success(())
             }
 
@@ -67,6 +66,6 @@ class LambdaRunnerTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handler: FailedHandler(Behavior.error)))
+        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handlerType: RuntimeErrorHandler.self))
     }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTest.swift
@@ -24,20 +24,20 @@ import XCTest
 class LambdaRuntimeClientTest: XCTestCase {
     func testSuccess() {
         let behavior = Behavior()
-        XCTAssertNoThrow(try runLambda(behavior: behavior, handler: EchoHandler()))
+        XCTAssertNoThrow(try runLambda(behavior: behavior, handlerType: EchoHandler.self))
         XCTAssertEqual(behavior.state, 6)
     }
 
     func testFailure() {
         let behavior = Behavior()
-        XCTAssertNoThrow(try runLambda(behavior: behavior, handler: FailedHandler("boom")))
+        XCTAssertNoThrow(try runLambda(behavior: behavior, handlerType: RuntimeErrorHandler.self))
         XCTAssertEqual(behavior.state, 10)
     }
 
-    func testBootstrapFailure() {
+    func testStartupFailure() {
         let behavior = Behavior()
-        XCTAssertThrowsError(try runLambda(behavior: behavior, factory: { $0.eventLoop.makeFailedFuture(TestError("boom")) })) { error in
-            XCTAssertEqual(error as? TestError, TestError("boom"))
+        XCTAssertThrowsError(try runLambda(behavior: behavior, handlerType: StartupErrorHandler.self)) {
+            XCTAssert($0 is StartupError)
         }
         XCTAssertEqual(behavior.state, 1)
     }
@@ -63,8 +63,8 @@ class LambdaRuntimeClientTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handler: EchoHandler())) { error in
-            XCTAssertEqual(error as? Lambda.RuntimeError, .badStatusCode(.internalServerError))
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerType: EchoHandler.self)) {
+            XCTAssertEqual($0 as? Lambda.RuntimeError, .badStatusCode(.internalServerError))
         }
     }
 
@@ -89,8 +89,8 @@ class LambdaRuntimeClientTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handler: EchoHandler())) { error in
-            XCTAssertEqual(error as? Lambda.RuntimeError, .noBody)
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerType: EchoHandler.self)) {
+            XCTAssertEqual($0 as? Lambda.RuntimeError, .noBody)
         }
     }
 
@@ -116,8 +116,8 @@ class LambdaRuntimeClientTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handler: EchoHandler())) { error in
-            XCTAssertEqual(error as? Lambda.RuntimeError, .invocationMissingHeader(AmazonHeaders.requestID))
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerType: EchoHandler.self)) {
+            XCTAssertEqual($0 as? Lambda.RuntimeError, .invocationMissingHeader(AmazonHeaders.requestID))
         }
     }
 
@@ -141,8 +141,8 @@ class LambdaRuntimeClientTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handler: EchoHandler())) { error in
-            XCTAssertEqual(error as? Lambda.RuntimeError, .badStatusCode(.internalServerError))
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerType: EchoHandler.self)) {
+            XCTAssertEqual($0 as? Lambda.RuntimeError, .badStatusCode(.internalServerError))
         }
     }
 
@@ -166,8 +166,8 @@ class LambdaRuntimeClientTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handler: FailedHandler("boom"))) { error in
-            XCTAssertEqual(error as? Lambda.RuntimeError, .badStatusCode(.internalServerError))
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerType: RuntimeErrorHandler.self)) {
+            XCTAssertEqual($0 as? Lambda.RuntimeError, .badStatusCode(.internalServerError))
         }
     }
 
@@ -192,8 +192,8 @@ class LambdaRuntimeClientTest: XCTestCase {
                 .failure(.internalServerError)
             }
         }
-        XCTAssertThrowsError(try runLambda(behavior: Behavior(), factory: { $0.eventLoop.makeFailedFuture(TestError("boom")) })) { error in
-            XCTAssertEqual(error as? TestError, TestError("boom"))
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerType: StartupErrorHandler.self)) {
+            XCTAssert($0 is StartupError)
         }
     }
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeTest.swift
@@ -72,7 +72,7 @@ class LambdaRuntimeTest: XCTestCase {
             typealias Event = String
             typealias Output = Void
 
-            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<ShutdownErrorHandler> {
+            static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<ShutdownErrorHandler> {
                 context.eventLoop.makeSucceededFuture(ShutdownErrorHandler())
             }
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeTest.swift
@@ -29,37 +29,16 @@ class LambdaRuntimeTest: XCTestCase {
 
         let eventLoop = eventLoopGroup.next()
         let logger = Logger(label: "TestLogger")
-        let testError = TestError("kaboom")
-        let runtime = LambdaRuntime(eventLoop: eventLoop, logger: logger, factory: {
-            $0.eventLoop.makeFailedFuture(testError)
-        })
+        let runtime = LambdaRuntime<StartupErrorHandler>(eventLoop: eventLoop, logger: logger)
 
         // eventLoop.submit in this case returns an EventLoopFuture<EventLoopFuture<ByteBufferHandler>>
         // which is why we need `wait().wait()`
-        XCTAssertThrowsError(try eventLoop.flatSubmit { runtime.start() }.wait()) { error in
-            XCTAssertEqual(testError, error as? TestError)
+        XCTAssertThrowsError(try eventLoop.flatSubmit { runtime.start() }.wait()) {
+            XCTAssert($0 is StartupError)
         }
 
-        XCTAssertThrowsError(_ = try runtime.shutdownFuture.wait()) { error in
-            XCTAssertEqual(testError, error as? TestError)
-        }
-    }
-
-    struct CallbackLambdaHandler: ByteBufferLambdaHandler {
-        let handler: (LambdaContext, ByteBuffer) -> (EventLoopFuture<ByteBuffer?>)
-        let shutdown: (Lambda.ShutdownContext) -> EventLoopFuture<Void>
-
-        init(_ handler: @escaping (LambdaContext, ByteBuffer) -> (EventLoopFuture<ByteBuffer?>), shutdown: @escaping (Lambda.ShutdownContext) -> EventLoopFuture<Void>) {
-            self.handler = handler
-            self.shutdown = shutdown
-        }
-
-        func handle(_ event: ByteBuffer, context: LambdaContext) -> EventLoopFuture<ByteBuffer?> {
-            self.handler(context, event)
-        }
-
-        func shutdown(context: Lambda.ShutdownContext) -> EventLoopFuture<Void> {
-            self.shutdown(context)
+        XCTAssertThrowsError(_ = try runtime.shutdownFuture.wait()) {
+            XCTAssert($0 is StartupError)
         }
     }
 
@@ -70,23 +49,14 @@ class LambdaRuntimeTest: XCTestCase {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
 
-        var count = 0
-        let handler = CallbackLambdaHandler({ XCTFail("Should not be reached"); return $0.eventLoop.makeSucceededFuture($1) }) { context in
-            count += 1
-            return context.eventLoop.makeSucceededFuture(())
-        }
-
         let eventLoop = eventLoopGroup.next()
         let logger = Logger(label: "TestLogger")
-        let runtime = LambdaRuntime(eventLoop: eventLoop, logger: logger, factory: {
-            $0.eventLoop.makeSucceededFuture(handler)
-        })
+        let runtime = LambdaRuntime<EchoHandler>(eventLoop: eventLoop, logger: logger)
 
         XCTAssertNoThrow(_ = try eventLoop.flatSubmit { runtime.start() }.wait())
-        XCTAssertThrowsError(_ = try runtime.shutdownFuture.wait()) { error in
-            XCTAssertEqual(.badStatusCode(HTTPResponseStatus.internalServerError), error as? Lambda.RuntimeError)
+        XCTAssertThrowsError(_ = try runtime.shutdownFuture.wait()) {
+            XCTAssertEqual(.badStatusCode(HTTPResponseStatus.internalServerError), $0 as? Lambda.RuntimeError)
         }
-        XCTAssertEqual(count, 1)
     }
 
     func testLambdaResultIfShutsdownIsUnclean() {
@@ -96,28 +66,19 @@ class LambdaRuntimeTest: XCTestCase {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
 
-        var count = 0
-        let handler = CallbackLambdaHandler({ XCTFail("Should not be reached"); return $0.eventLoop.makeSucceededFuture($1) }) { context in
-            count += 1
-            return context.eventLoop.makeFailedFuture(TestError("kaboom"))
-        }
-
         let eventLoop = eventLoopGroup.next()
         let logger = Logger(label: "TestLogger")
-        let runtime = LambdaRuntime(eventLoop: eventLoop, logger: logger, factory: {
-            $0.eventLoop.makeSucceededFuture(handler)
-        })
+        let runtime = LambdaRuntime<RuntimeErrorHandler>(eventLoop: eventLoop, logger: logger)
 
-        XCTAssertNoThrow(_ = try eventLoop.flatSubmit { runtime.start() }.wait())
-        XCTAssertThrowsError(_ = try runtime.shutdownFuture.wait()) { error in
+        XCTAssertNoThrow(try eventLoop.flatSubmit { runtime.start() }.wait())
+        XCTAssertThrowsError(try runtime.shutdownFuture.wait()) { error in
             guard case Lambda.RuntimeError.shutdownError(let shutdownError, .failure(let runtimeError)) = error else {
-                XCTFail("Unexpected error"); return
+                XCTFail("Unexpected error: \(error)"); return
             }
 
             XCTAssertEqual(shutdownError as? TestError, TestError("kaboom"))
             XCTAssertEqual(runtimeError as? Lambda.RuntimeError, .badStatusCode(.internalServerError))
         }
-        XCTAssertEqual(count, 1)
     }
 }
 

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
@@ -42,7 +42,7 @@ class CodableLambdaTest: XCTestCase {
             typealias Output = Void
 
             var expected: Request?
-            
+
             static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
@@ -71,7 +71,7 @@ class CodableLambdaTest: XCTestCase {
             typealias Output = Response
 
             var expected: Request?
-            
+
             static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
@@ -41,7 +41,11 @@ class CodableLambdaTest: XCTestCase {
             typealias Event = Request
             typealias Output = Void
 
-            let expected: Request
+            var expected: Request?
+            
+            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+                context.eventLoop.makeSucceededFuture(Handler())
+            }
 
             func handle(_ event: Request, context: LambdaContext) -> EventLoopFuture<Void> {
                 XCTAssertEqual(event, self.expected)
@@ -66,7 +70,11 @@ class CodableLambdaTest: XCTestCase {
             typealias Event = Request
             typealias Output = Response
 
-            let expected: Request
+            var expected: Request?
+            
+            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+                context.eventLoop.makeSucceededFuture(Handler())
+            }
 
             func handle(_ event: Request, context: LambdaContext) -> EventLoopFuture<Response> {
                 XCTAssertEqual(event, self.expected)

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
@@ -43,7 +43,7 @@ class CodableLambdaTest: XCTestCase {
 
             var expected: Request?
 
-            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+            static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
@@ -72,7 +72,7 @@ class CodableLambdaTest: XCTestCase {
 
             var expected: Request?
 
-            static func factory(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
+            static func makeHandler(context: Lambda.InitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 


### PR DESCRIPTION
As previously discussed...

We want to use the same lambda application lifecycle for all lambda implementations. Currently we support `@main` only for the `LambdaHandler` protocol. This PR brings the `@main` functionality to the lower level protocols.

### Modifications:

- Add a factory method requirement to the `ByteBufferLambdaHandler` protocol
- Remove the factory callback (`HandlerFactory`) from the `LambdaRuntime` and `Lambda`
- Make the `LambdaRuntime` generic over the `LambdaHandler` type
- Adjust tests
- Write better docu

### Result:

- The application lifecycle is the same for all protocol levels.
