### PR TITLE
Add default value for traceID header

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/ControlPlaneRequest.swift
+++ b/Sources/AWSLambdaRuntimeCore/ControlPlaneRequest.swift
@@ -54,7 +54,8 @@ struct Invocation: Hashable {
         self.requestID = requestID
         self.deadlineInMillisSinceEpoch = unixTimeInMilliseconds
         self.invokedFunctionARN = invokedFunctionARN
-        self.traceID = headers.first(name: AmazonHeaders.traceID) ?? ""
+        self.traceID = headers.first(name: AmazonHeaders.traceID) ?? 
+            "Root=\(AmazonHeaders.generateXRayTraceID());Sampled=0"
         self.clientContext = headers["Lambda-Runtime-Client-Context"].first
         self.cognitoIdentity = headers["Lambda-Runtime-Cognito-Identity"].first
     }

--- a/Sources/AWSLambdaRuntimeCore/ControlPlaneRequest.swift
+++ b/Sources/AWSLambdaRuntimeCore/ControlPlaneRequest.swift
@@ -51,14 +51,10 @@ struct Invocation: Hashable {
             throw Lambda.RuntimeError.invocationMissingHeader(AmazonHeaders.invokedFunctionARN)
         }
 
-        guard let traceID = headers.first(name: AmazonHeaders.traceID) else {
-            throw Lambda.RuntimeError.invocationMissingHeader(AmazonHeaders.traceID)
-        }
-
         self.requestID = requestID
         self.deadlineInMillisSinceEpoch = unixTimeInMilliseconds
         self.invokedFunctionARN = invokedFunctionARN
-        self.traceID = traceID
+        self.traceID = headers.first(name: AmazonHeaders.traceID) ?? ""
         self.clientContext = headers["Lambda-Runtime-Client-Context"].first
         self.cognitoIdentity = headers["Lambda-Runtime-Cognito-Identity"].first
     }

--- a/Sources/AWSLambdaRuntimeCore/ControlPlaneRequest.swift
+++ b/Sources/AWSLambdaRuntimeCore/ControlPlaneRequest.swift
@@ -54,8 +54,7 @@ struct Invocation: Hashable {
         self.requestID = requestID
         self.deadlineInMillisSinceEpoch = unixTimeInMilliseconds
         self.invokedFunctionARN = invokedFunctionARN
-        self.traceID = headers.first(name: AmazonHeaders.traceID) ?? 
-            "Root=\(AmazonHeaders.generateXRayTraceID());Sampled=0"
+        self.traceID = headers.first(name: AmazonHeaders.traceID) ?? "Root=\(AmazonHeaders.generateXRayTraceID());Sampled=0"
         self.clientContext = headers["Lambda-Runtime-Client-Context"].first
         self.cognitoIdentity = headers["Lambda-Runtime-Cognito-Identity"].first
     }

--- a/Tests/AWSLambdaRuntimeCoreTests/ControlPlaneRequestTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/ControlPlaneRequestTests.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import AWSLambdaRuntimeCore
+import NIOHTTP1
+import XCTest
+
+class InvocationTest: XCTestCase {
+    func testInvocationTraceID() throws {
+        let headers = HTTPHeaders([
+            (AmazonHeaders.requestID, "test"),
+            (AmazonHeaders.deadline, String(Date(timeIntervalSinceNow: 60).millisSinceEpoch)),
+            (AmazonHeaders.invokedFunctionARN, "arn:aws:lambda:us-east-1:123456789012:function:custom-runtime"),
+        ])
+
+        var invocation: Invocation?
+
+        XCTAssertNoThrow(invocation = try Invocation(headers: headers))
+        XCTAssertNotNil(invocation)
+
+        guard !invocation!.traceID.isEmpty else {
+            XCTFail("Invocation traceID is empty")
+            return
+        }
+    }
+}

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -19,7 +19,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2017-2018/YEARS/' -e 's/2017-2020/YEARS/' -e 's/2017-2021/YEARS/' -e 's/2020-2021/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
+    sed -e 's/2017-2018/YEARS/' -e 's/2017-2020/YEARS/' -e 's/2017-2021/YEARS/' -e 's/2020-2021/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/' -e 's/2022/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
Adds a default value for the Lambda-Runtime-Trace-Id header, to make it compatible with the AWS SAM CLI and other applications depending on the Lambda Runtime Interface Emulator. 

### Motivation:

Currently the Swift Runtime is incompatible with the Lambda Runtime Interface Emulator.

### Modifications:

Adds a default value for the Lambda-Runtime-Trace-Id header.

This is similar to what the [Rust runtime](https://github.com/awslabs/aws-lambda-rust-runtime/blob/f33fa059a88869b38646d875688fab58885208de/lambda-runtime/src/types.rs#L157) is doing.

### Result:

The Swift Runtime will be compatible with the Lambda Runtime Interface Emulator.
