### PR TITLE
ci update

### DIFF
--- a/docker/docker-compose.al2.56.yaml
+++ b/docker/docker-compose.al2.56.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-aws-lambda:al2-5.6
+    build:
+      args:
+        swift_version: "5.6"
+
+  test:
+    image: swift-aws-lambda:al2-5.6
+
+  test-samples:
+    image: swift-aws-lambda:al2-5.6
+
+  shell:
+    image: swift-aws-lambda:al2-5.6

--- a/docker/docker-compose.al2.57.yaml
+++ b/docker/docker-compose.al2.57.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-aws-lambda:al2-5.7
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-main-amazonlinux2"
+
+  test:
+    image: swift-aws-lambda:al2-5.7
+
+  test-samples:
+    image: swift-aws-lambda:al2-5.7
+
+  shell:
+    image: swift-aws-lambda:al2-5.7


### PR DESCRIPTION
motivation: 5.6 is out

changes:
* use release version of 5.6
* add docker setup for 5.7 (using nightly for now)
