### PR TITLE
adoption of sendable

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -12,9 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.6)
+@preconcurrency import Dispatch
+@preconcurrency import Logging
+@preconcurrency import NIOCore
+#else
 import Dispatch
 import Logging
 import NIOCore
+#endif
 
 // MARK: - InitializationContext
 
@@ -23,7 +29,7 @@ extension Lambda {
     /// The Lambda runtime generates and passes the `InitializationContext` to the Handlers
     /// ``ByteBufferLambdaHandler/makeHandler(context:)`` or ``LambdaHandler/init(context:)``
     /// as an argument.
-    public struct InitializationContext {
+    public struct InitializationContext: _AWSLambdaSendable {
         /// `Logger` to log with
         ///
         /// - note: The `LogLevel` can be configured using the `LOG_LEVEL` environment variable.
@@ -67,17 +73,17 @@ extension Lambda {
 
 /// Lambda runtime context.
 /// The Lambda runtime generates and passes the `Context` to the Lambda handler as an argument.
-public struct LambdaContext: CustomDebugStringConvertible {
-    final class _Storage {
-        var requestID: String
-        var traceID: String
-        var invokedFunctionARN: String
-        var deadline: DispatchWallTime
-        var cognitoIdentity: String?
-        var clientContext: String?
-        var logger: Logger
-        var eventLoop: EventLoop
-        var allocator: ByteBufferAllocator
+public struct LambdaContext: CustomDebugStringConvertible, _AWSLambdaSendable {
+    final class _Storage: _AWSLambdaSendable {
+        let requestID: String
+        let traceID: String
+        let invokedFunctionARN: String
+        let deadline: DispatchWallTime
+        let cognitoIdentity: String?
+        let clientContext: String?
+        let logger: Logger
+        let eventLoop: EventLoop
+        let allocator: ByteBufferAllocator
 
         init(
             requestID: String,

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -26,7 +26,7 @@ import NIOCore
 ///         level protocols ``EventLoopLambdaHandler`` and
 ///         ``ByteBufferLambdaHandler``.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public protocol LambdaHandler: EventLoopLambdaHandler {
+public protocol LambdaHandler: EventLoopLambdaHandler where Event: _AWSLambdaSendable {
     /// The Lambda initialization method
     /// Use this method to initialize resources that will be used in every request.
     ///
@@ -157,7 +157,7 @@ extension EventLoopLambdaHandler where Output == Void {
 /// - note: This is a low level protocol designed to power the higher level ``EventLoopLambdaHandler`` and
 ///         ``LambdaHandler`` based APIs.
 ///         Most users are not expected to use this protocol.
-public protocol ByteBufferLambdaHandler {
+public protocol ByteBufferLambdaHandler: _ByteBufferLambdaHandlerSendable {
     /// Create your Lambda handler for the runtime.
     ///
     /// Use this to initialize all your resources that you want to cache between invocations. This could be database

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -189,3 +189,8 @@ public final class LambdaRuntime<Handler: ByteBufferLambdaHandler> {
         }
     }
 }
+
+// TODO: ideally this would not be @unchecked Sendable, but Sendable checks do not understand locks
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension LambdaRuntime: @unchecked Sendable {}
+#endif

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -189,8 +189,3 @@ public final class LambdaRuntime<Handler: ByteBufferLambdaHandler> {
         }
     }
 }
-
-// TODO: ideally this would not be @unchecked Sendable, but Sendable checks do not understand locks
-#if compiler(>=5.5) && canImport(_Concurrency)
-extension LambdaRuntime: @unchecked Sendable {}
-#endif

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -197,7 +197,7 @@ public final class LambdaRuntime<Handler: ByteBufferLambdaHandler> {
     }
 }
 
-/// This is safe since lambda runtime is intended to be used within a single `EventLoop`
+/// This is safe since lambda runtime synchronizes by dispatching all methods to a single `EventLoop`
 #if compiler(>=5.5) && canImport(_Concurrency)
 extension LambdaRuntime: @unchecked Sendable {}
 #endif

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -13,8 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
+#if compiler(>=5.6)
+@preconcurrency import NIOCore
+@preconcurrency import NIOHTTP1
+#else
 import NIOCore
 import NIOHTTP1
+#endif
 
 /// An HTTP based client for AWS Runtime Engine. This encapsulates the RESTful methods exposed by the Runtime Engine:
 /// * /runtime/invocation/next

--- a/Sources/AWSLambdaRuntimeCore/Sendable.swift
+++ b/Sources/AWSLambdaRuntimeCore/Sendable.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// Sendable bridging types
+
+#if compiler(>=5.6)
+@preconcurrency public protocol _ByteBufferLambdaHandlerSendable: Sendable {}
+#else
+public protocol _ByteBufferLambdaHandlerSendable {}
+#endif
+
+#if compiler(>=5.6)
+public typealias _AWSLambdaSendable = Sendable
+#else
+public typealias _AWSLambdaSendable = Any
+#endif

--- a/Sources/AWSLambdaRuntimeCore/Sendable.swift
+++ b/Sources/AWSLambdaRuntimeCore/Sendable.swift
@@ -15,12 +15,6 @@
 // Sendable bridging types
 
 #if compiler(>=5.6)
-@preconcurrency public protocol _ByteBufferLambdaHandlerSendable: Sendable {}
-#else
-public protocol _ByteBufferLambdaHandlerSendable {}
-#endif
-
-#if compiler(>=5.6)
 public typealias _AWSLambdaSendable = Sendable
 #else
 public typealias _AWSLambdaSendable = Any

--- a/Sources/AWSLambdaRuntimeCore/Terminator.swift
+++ b/Sources/AWSLambdaRuntimeCore/Terminator.swift
@@ -138,7 +138,8 @@ extension LambdaTerminator {
     }
 }
 
-// TODO: ideally this would not be @unchecked Sendable, but Sendable checks do not understand locks
+// Ideally this would not be @unchecked Sendable, but Sendable checks do not understand locks
+// We can transition this to an actor once we drop support for older Swift versions
 #if compiler(>=5.5) && canImport(_Concurrency)
 extension LambdaTerminator: @unchecked Sendable {}
 extension LambdaTerminator.Storage: @unchecked Sendable {}

--- a/Sources/AWSLambdaRuntimeCore/Terminator.swift
+++ b/Sources/AWSLambdaRuntimeCore/Terminator.swift
@@ -18,7 +18,7 @@ import NIOCore
 /// Lambda terminator.
 /// Utility to manage the lambda shutdown sequence.
 public final class LambdaTerminator {
-    private typealias Handler = (EventLoop) -> EventLoopFuture<Void>
+    fileprivate typealias Handler = (EventLoop) -> EventLoopFuture<Void>
 
     private var storage: Storage
 
@@ -99,7 +99,7 @@ extension LambdaTerminator {
 }
 
 extension LambdaTerminator {
-    private final class Storage {
+    fileprivate final class Storage {
         private let lock: Lock
         private var index: [RegistrationKey]
         private var map: [RegistrationKey: (name: String, handler: Handler)]
@@ -137,3 +137,9 @@ extension LambdaTerminator {
         let underlying: [Error]
     }
 }
+
+// TODO: ideally this would not be @unchecked Sendable, but Sendable checks do not understand locks
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension LambdaTerminator: @unchecked Sendable {}
+extension LambdaTerminator.Storage: @unchecked Sendable {}
+#endif

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swiftformat (until part of the toolchain)
 
-ARG swiftformat_version=0.47.3
+ARG swiftformat_version=0.49.6
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
 RUN cd $HOME/.tools/swift-format && swift build -c release
 RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swiftformat (until part of the toolchain)
 
-ARG swiftformat_version=0.49.6
+ARG swiftformat_version=0.47.3
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
 RUN cd $HOME/.tools/swift-format && swift build -c release
 RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat


### PR DESCRIPTION
motivation: adopt to sendable requirments in swift 5.6

changes:
* define sendable shims for protocols and structs that may be used in async context
* adjust tests
* add a test to make sure no warning are emittted
