### PR TITLE
Add async LambdaHandler.shutdown

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -79,8 +79,7 @@ extension LambdaHandler {
         return promise.futureResult
     }
 
-    public func shutdown(context: Lambda.ShutdownContext) async throws {
-    }
+    public func shutdown(context: Lambda.ShutdownContext) async throws {}
 }
 
 #endif


### PR DESCRIPTION
Add async shutdown method to `LambdaHandler` protocol

### Motivation:

`LambdaHandler` provides async interfaces for `init` and `handle` but not `shutdown`

### Modifications:

- Add protocol requirement `shutdown(context: Lambda.ShutdownContext) async throws` to `LambdaHandler`
- Add default version that does nothing in extension
- Override ByteBufferLambdaHandler.shutdown to call the async version from `LambdaHandler` in extension

### Result:

Can shutdown LambdaHandler using async methods eg
```swift
final class MyLambda: LambdaHandler {
    init(context: Lambda.InitializationContext) {
        self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(context.eventLoop))
    }

    func shutdown(context: Lambda.ShutdownContext) async throws {
        try await self.httpClient.shutdown()
    }
}
```