### PR TITLE
remove extension for JSONEncoder and JSONDecoder

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -76,17 +76,3 @@ extension JSONEncoder: LambdaCodableEncoder {
         return buffer
     }
 }
-
-extension JSONEncoder {
-    /// Convenience method to allow encoding json directly into a `String`. It can be used to encode a payload into an `APIGateway.V2.Response`'s body.
-    public func encodeAsString<T: Encodable>(_ value: T) throws -> String {
-        try String(decoding: self.encode(value), as: Unicode.UTF8.self)
-    }
-}
-
-extension JSONDecoder {
-    /// Convenience method to allow decoding json directly from a `String`. It can be used to decode a payload from an `APIGateway.V2.Request`'s body.
-    public func decode<T: Decodable>(_ type: T.Type, from string: String) throws -> T {
-        try self.decode(type, from: Data(string.utf8))
-    }
-}


### PR DESCRIPTION
motivation: we should not publicly extend types we do not own

change: remove extensions which are largely API sugar that is not directly related to Lambda
