### PR TITLE
add new abstraction for simple Lambda that does not need explicit initialization

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -84,6 +84,31 @@ fileprivate struct UncheckedSendableHandler<Underlying: LambdaHandler, Event, Ou
 }
 #endif
 
+// MARK: - SimpleLambdaHandler
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+/// Strongly typed, processing protocol for a Lambda that takes a user defined
+/// ``EventLoopLambdaHandler/Event`` and returns a user defined
+/// ``EventLoopLambdaHandler/Output`` asynchronously.
+///
+/// - note: Simpler use cases that do not special initialization should implement this protocol instead of the lower
+///         level protocols ``LambdaHandler``,
+///         ``EventLoopLambdaHandler`` and
+///         ``ByteBufferLambdaHandler``.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol SimpleLambdaHandler: LambdaHandler {
+    init()
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension SimpleLambdaHandler {
+    init(context: LambdaInitializationContext) async throws {
+        // no-op initialization, which simple LambdaHandler that do not need initialization
+        self.init()
+    }
+}
+#endif
+
 // MARK: - EventLoopLambdaHandler
 
 /// Strongly typed, `EventLoopFuture` based processing protocol for a Lambda that takes a user

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -146,6 +146,27 @@ class LambdaHandlerTest: XCTestCase {
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
     }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testSimpleLambdaHandler() {
+        let server = MockLambdaServer(behavior: Behavior())
+        XCTAssertNoThrow(try server.start().wait())
+        defer { XCTAssertNoThrow(try server.stop().wait()) }
+
+        struct Handler: SimpleLambdaHandler {
+            typealias Event = String
+            typealias Output = String
+
+            func handle(_ event: String, context: LambdaContext) async throws -> String {
+                event
+            }
+        }
+
+        let maxTimes = Int.random(in: 1 ... 10)
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
+        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+    }
     #endif
 
     // MARK: - EventLoopLambdaHandler


### PR DESCRIPTION
motivation: make simple things simple

changes:
* add new abstraction names SimpleLambdaHandler that has a default initializer
* add test

