### PR TITLE
Add special Deployment instructions for the Mac M1

### DIFF
--- a/Examples/Deployment/README.md
+++ b/Examples/Deployment/README.md
@@ -13,6 +13,13 @@ cd swift-aws-lambda-runtime/Examples/Deployment
 
 Note: The example scripts assume you have [jq](https://stedolan.github.io/jq/download/) command line tool installed.
 
+## Mac M1 Considerations
+
+Lambdas will run on an x86 processor by default. Building a Lambda with an M1 will create an arm-based executable which will not run on an x86 processor. Here are a few options for building Swift Lambdas on an M1:
+
+1. Configure the Lambda to run on the [Graviton2](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/) Arm-based processor.
+2. Build with the x86 architecture by specifying `--platform linux/amd64` in all Docker 'build' and 'run' commands in `build-and-package.sh`.
+
 ## Deployment instructions using AWS CLI
 
 Steps to deploy this sample to AWS Lambda using the AWS CLI:


### PR DESCRIPTION
This adds brief notes on building from an M1 as I don't believe the samples will work without special adjustments.

### Motivation:

I had spent a few days attempting to build from my M1 but was a bit confused as to what was wrong. It turned out to be a very simple fix. 

### Modifications:

Update the Deployment documentation so that M1 users quickly know they need to make some adjustments before spending time trying to deploy the samples.

### Result:

Hopefully more users on M1s will be able to deploy the samples.
