### PR TITLE
Update README for 0.5.2 Package.swift

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ First, create a SwiftPM project and pull Swift AWS Lambda Runtime as dependency 
          .executable(name: "MyLambda", targets: ["MyLambda"]),
      ],
      dependencies: [
-         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "0.1.0"),
+         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "0.5.2"),
      ],
      targets: [
          .target(name: "MyLambda", dependencies: [
@@ -90,8 +90,7 @@ First, add a dependency on the event packages:
          .executable(name: "MyLambda", targets: ["MyLambda"]),
      ],
      dependencies: [
-         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "0.1.0"),
-         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.1.0"),
+         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "0.5.2"),
      ],
      targets: [
          .target(name: "MyLambda", dependencies: [


### PR DESCRIPTION
A simple update to make the README file compatible with the latest version 0.5.2 configuration

### Motivation:

When testing the library following the README guidelines, I was unable to build the project. In research and looking at the release pages I saw more current versions and the non-use of event url as a dependency. In order to facilitate a first use, I decided to open this pull request with this small correction.
### Modifications:

Update dependencies:

```swift
     dependencies: [
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "0.5.2"),
     ],
```

### Result:

N/A
