### PR TITLE
Improves Developer Ergonomics for LambdaHandler Conformances

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,6 @@ let package = Package(
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
         ]),
         .testTarget(name: "AWSLambdaRuntimeTests", dependencies: [
-            .byName(name: "AWSLambdaRuntimeCore"),
             .byName(name: "AWSLambdaRuntime"),
         ]),
         // testing helper

--- a/Sources/AWSLambdaRuntimeCore/HTTPClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/HTTPClient.swift
@@ -172,8 +172,6 @@ private final class LambdaChannelHandler: ChannelDuplexHandler {
     private var state: State = .idle
     private var lastError: Error?
 
-    init() {}
-
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         guard case .idle = self.state else {
             preconditionFailure("invalid state, outstanding request")

--- a/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+LocalServer.swift
@@ -36,17 +36,16 @@ extension Lambda {
     ///     - body: Code to run within the context of the mock server. Typically this would be a Lambda.run function call.
     ///
     /// - note: This API is designed strictly for local testing and is behind a DEBUG flag
-    internal static func withLocalServer<Value>(invocationEndpoint: String? = nil, _ body: @escaping () -> Value) throws -> Value {
+    internal static func startLocalServer(invocationEndpoint: String? = nil) throws -> LocalLambda.Server {
         let server = LocalLambda.Server(invocationEndpoint: invocationEndpoint)
         try server.start().wait()
-        defer { try! server.stop() }
-        return body()
+        return server
     }
 }
 
 // MARK: - Local Mock Server
 
-private enum LocalLambda {
+internal enum LocalLambda {
     struct Server {
         private let logger: Logger
         private let group: EventLoopGroup

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -16,7 +16,7 @@ import NIOCore
 extension EventLoopLambdaHandler where Event == String {
     /// Implementation of a `ByteBuffer` to `String` decoding.
     @inlinable
-    public func decode(buffer: ByteBuffer) throws -> String {
+    public func decode(buffer: ByteBuffer) throws -> Event {
         var buffer = buffer
         guard let string = buffer.readString(length: buffer.readableBytes) else {
             fatalError("buffer.readString(length: buffer.readableBytes) failed")
@@ -28,7 +28,7 @@ extension EventLoopLambdaHandler where Event == String {
 extension EventLoopLambdaHandler where Output == String {
     /// Implementation of `String` to `ByteBuffer` encoding.
     @inlinable
-    public func encode(allocator: ByteBufferAllocator, value: String) throws -> ByteBuffer? {
+    public func encode(allocator: ByteBufferAllocator, value: Output) throws -> ByteBuffer? {
         // FIXME: reusable buffer
         var buffer = allocator.buffer(capacity: value.utf8.count)
         buffer.writeString(value)

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -73,7 +73,7 @@ public enum Lambda {
 
         // start local server for debugging in DEBUG mode only
         #if DEBUG
-        if Lambda.env("LOCAL_LAMBDA_SERVER_ENABLED").flatMap(Bool.init) ?? false {
+        if Lambda.isLocalServer {
             do {
                 return try Lambda.withLocalServer {
                     _run(configuration)
@@ -93,6 +93,13 @@ public enum Lambda {
 // MARK: - Public API
 
 extension Lambda {
+    #if DEBUG
+    static var isLocalServer: Bool {
+        get { env("LOCAL_LAMBDA_SERVER_ENABLED").flatMap(Bool.init) ?? false }
+        set { setenv("LOCAL_LAMBDA_SERVER_ENABLED", String(newValue), 1) }
+    }
+    #endif
+    
     /// Utility to access/read environment variables
     public static func env(_ name: String) -> String? {
         guard let value = getenv(name) else {

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -43,7 +43,7 @@ public enum Lambda {
         // start local server for debugging in DEBUG mode only
         #if DEBUG
         var localServer: LocalLambda.Server? = nil
-        if Handler.isLocalServer || env("LOCAL_LAMBDA_SERVER_ENABLED").flatMap(Bool.init) ?? false {
+        if Handler.isLocalServer {
             localServer = try Lambda.startLocalServer()
         }
         #endif

--- a/Sources/AWSLambdaRuntimeCore/LambdaConfiguration.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaConfiguration.swift
@@ -17,26 +17,12 @@ import Logging
 import NIOCore
 
 internal struct LambdaConfiguration: CustomStringConvertible {
-    let general: General
-    let lifecycle: Lifecycle
-    let runtimeEngine: RuntimeEngine
-
-    init() {
-        self.init(general: .init(), lifecycle: .init(), runtimeEngine: .init())
-    }
-
-    init(general: General? = nil, lifecycle: Lifecycle? = nil, runtimeEngine: RuntimeEngine? = nil) {
-        self.general = general ?? General()
-        self.lifecycle = lifecycle ?? Lifecycle()
-        self.runtimeEngine = runtimeEngine ?? RuntimeEngine()
-    }
+    var general: General = .init()
+    var lifecycle: Lifecycle = .init()
+    var runtimeEngine: RuntimeEngine = .init()
 
     struct General: CustomStringConvertible {
-        let logLevel: Logger.Level
-
-        init(logLevel: Logger.Level? = nil) {
-            self.logLevel = logLevel ?? Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? .info
-        }
+        var logLevel = Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? .info
 
         var description: String {
             "\(General.self)(logLevel: \(self.logLevel))"
@@ -44,15 +30,10 @@ internal struct LambdaConfiguration: CustomStringConvertible {
     }
 
     struct Lifecycle: CustomStringConvertible {
-        let id: String
-        let maxTimes: Int
-        let stopSignal: Signal
-
-        init(id: String? = nil, maxTimes: Int? = nil, stopSignal: Signal? = nil) {
-            self.id = id ?? "\(DispatchTime.now().uptimeNanoseconds)"
-            self.maxTimes = maxTimes ?? Lambda.env("MAX_REQUESTS").flatMap(Int.init) ?? 0
-            self.stopSignal = stopSignal ?? Lambda.env("STOP_SIGNAL").flatMap(Int32.init).flatMap(Signal.init) ?? Signal.TERM
-            precondition(self.maxTimes >= 0, "maxTimes must be equal or larger than 0")
+        var id: String = "\(DispatchTime.now().uptimeNanoseconds)"
+        var stopSignal: Signal = Lambda.env("STOP_SIGNAL").flatMap(Int32.init).flatMap(Signal.init) ?? Signal.TERM
+        var maxTimes: Int = Lambda.env("MAX_REQUESTS").flatMap(Int.init) ?? 0 {
+            didSet { precondition(self.maxTimes >= 0, "maxTimes must be equal or larger than 0") }
         }
 
         var description: String {

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -45,6 +45,43 @@ public struct LambdaInitializationContext: _AWSLambdaSendable {
 
     /// ``LambdaTerminator`` to register shutdown operations.
     public let terminator: LambdaTerminator
+    
+    #if DEBUG
+    /// A flag that determines if the Lambda should run as a local server.
+    ///
+    /// This flag defaults to the value of the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable.
+    /// This property serves as an override point for types conforming to ``LambdaHandler``:
+    ///
+    /// ```swift
+    /// import AWSLambdaRuntime
+    /// import Foundation
+    ///
+    /// @main
+    /// struct EntryHandler: LambdaHandler {
+    ///     typealias Event = <#YourCodableEventType#>
+    ///     typealias Output = <#YourCodableResponseType#>
+    ///
+    ///     init(context: LambdaInitializationContext) async throws {
+    ///         // You can specify this Lambda as a local server here
+    ///         context.isLocalServer = true
+    ///     }
+    ///
+    ///     func handle(_ event: Event, context: LambdaContext) async throws -> Output {
+    ///         try await yourClient.getResponse(for: event)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - note: This flag is a no-op on non-`DEBUG` builds. If your code conditionally compiles
+    /// using the `#if DEBUG` compilation flag, then this flag can be used to inform the Lambda to
+    /// run as a local server.
+    public var isLocalServer: Bool {
+        get { Lambda.isLocalServer }
+        set { Lambda.isLocalServer = newValue }
+    }
+    #else
+    public let isLocalServer = false
+    #endif
 
     init(logger: Logger, eventLoop: EventLoop, allocator: ByteBufferAllocator, terminator: LambdaTerminator) {
         self.eventLoop = eventLoop

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -47,34 +47,6 @@ public struct LambdaInitializationContext: _AWSLambdaSendable {
     public let terminator: LambdaTerminator
     
     #if DEBUG
-    /// A flag that determines if the Lambda should run as a local server.
-    ///
-    /// This flag defaults to the value of the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable.
-    /// This property serves as an override point for types conforming to ``LambdaHandler``:
-    ///
-    /// ```swift
-    /// import AWSLambdaRuntime
-    /// import Foundation
-    ///
-    /// @main
-    /// struct EntryHandler: LambdaHandler {
-    ///     typealias Event = <#YourCodableEventType#>
-    ///     typealias Output = <#YourCodableResponseType#>
-    ///
-    ///     init(context: LambdaInitializationContext) async throws {
-    ///         // You can specify this Lambda as a local server here
-    ///         context.isLocalServer = true
-    ///     }
-    ///
-    ///     func handle(_ event: Event, context: LambdaContext) async throws -> Output {
-    ///         try await yourClient.getResponse(for: event)
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// - note: This flag is a no-op on non-`DEBUG` builds. If your code conditionally compiles
-    /// using the `#if DEBUG` compilation flag, then this flag can be used to inform the Lambda to
-    /// run as a local server.
     public var isLocalServer: Bool {
         get { Lambda.isLocalServer }
         set { Lambda.isLocalServer = newValue }
@@ -88,6 +60,45 @@ public struct LambdaInitializationContext: _AWSLambdaSendable {
         self.logger = logger
         self.allocator = allocator
         self.terminator = terminator
+    }
+    
+    /// Informs the Lambda whether or not it should run as a local server.
+    ///
+    /// This function is akin to setting the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable
+    /// without having to edit a scheme in Xcode or your shell process and serves as an override
+    /// point for types that are initialized with a ``LambdaInitializationContext``. This is an
+    /// example of a simple LambdaHandler that uses Codable types for its associated `Event` and
+    /// `Output` types:
+    ///
+    /// ```swift
+    /// import AWSLambdaRuntime
+    /// import Foundation
+    ///
+    /// @main
+    /// struct EntryHandler: LambdaHandler {
+    ///     typealias Event = <#YourCodableEventType#>
+    ///     typealias Output = <#YourCodableResponseType#>
+    ///
+    ///     init(context: LambdaInitializationContext) async throws {
+    ///         // You can specify this Lambda as a local server here
+    ///         context.enableLocalServer()
+    ///     }
+    ///
+    ///     func handle(_ event: Event, context: LambdaContext) async throws -> Output {
+    ///         try await client.processResponse(for: event)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///  - enabled: A `Bool` that overrides the process' `LOCAL_LAMBDA_SERVER_ENABLED` environment
+    ///  variable to the passed-in value. Defaults to `true`.
+    ///
+    /// - note: This function is a no-op on non-`DEBUG` builds. If your project conditionally
+    /// compiles using the `#if DEBUG` compilation flag, then this flag can be used to inform the
+    /// Lambda to run as a local server.
+    public func enableLocalServer(_ enabled: Bool = true) {
+        Lambda.isLocalServer = enabled
     }
 
     /// This interface is not part of the public API and must not be used by adopters. This API is not part of semver versioning.

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -46,15 +46,6 @@ public struct LambdaInitializationContext: _AWSLambdaSendable {
     /// ``LambdaTerminator`` to register shutdown operations.
     public let terminator: LambdaTerminator
     
-    #if DEBUG
-    public var isLocalServer: Bool {
-        get { Lambda.isLocalServer }
-        set { Lambda.isLocalServer = newValue }
-    }
-    #else
-    public let isLocalServer = false
-    #endif
-
     init(logger: Logger, eventLoop: EventLoop, allocator: ByteBufferAllocator, terminator: LambdaTerminator) {
         self.eventLoop = eventLoop
         self.logger = logger
@@ -62,45 +53,6 @@ public struct LambdaInitializationContext: _AWSLambdaSendable {
         self.terminator = terminator
     }
     
-    /// Informs the Lambda whether or not it should run as a local server.
-    ///
-    /// This function is akin to setting the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable
-    /// without having to edit a scheme in Xcode or your shell process and serves as an override
-    /// point for types that are initialized with a ``LambdaInitializationContext``. This is an
-    /// example of a simple LambdaHandler that uses Codable types for its associated `Event` and
-    /// `Output` types:
-    ///
-    /// ```swift
-    /// import AWSLambdaRuntime
-    /// import Foundation
-    ///
-    /// @main
-    /// struct EntryHandler: LambdaHandler {
-    ///     typealias Event = <#YourCodableEventType#>
-    ///     typealias Output = <#YourCodableResponseType#>
-    ///
-    ///     init(context: LambdaInitializationContext) async throws {
-    ///         // You can specify this Lambda as a local server here
-    ///         context.enableLocalServer()
-    ///     }
-    ///
-    ///     func handle(_ event: Event, context: LambdaContext) async throws -> Output {
-    ///         try await client.processResponse(for: event)
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// - parameters:
-    ///  - enabled: A `Bool` that overrides the process' `LOCAL_LAMBDA_SERVER_ENABLED` environment
-    ///  variable to the passed-in value. Defaults to `true`.
-    ///
-    /// - note: This function is a no-op on non-`DEBUG` builds. If your project conditionally
-    /// compiles using the `#if DEBUG` compilation flag, then this flag can be used to inform the
-    /// Lambda to run as a local server.
-    public func enableLocalServer(_ enabled: Bool = true) {
-        Lambda.isLocalServer = enabled
-    }
-
     /// This interface is not part of the public API and must not be used by adopters. This API is not part of semver versioning.
     public static func __forTestsOnly(
         logger: Logger,

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -14,13 +14,12 @@
 
 #if compiler(>=5.6)
 @preconcurrency import Dispatch
-@preconcurrency import Logging
-@preconcurrency import NIOCore
 #else
 import Dispatch
+#endif
+
 import Logging
 import NIOCore
-#endif
 
 // MARK: - InitializationContext
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -192,24 +192,4 @@ public struct LambdaContext: CustomDebugStringConvertible, _AWSLambdaSendable {
     public var debugDescription: String {
         "\(Self.self)(requestID: \(self.requestID), traceID: \(self.traceID), invokedFunctionARN: \(self.invokedFunctionARN), cognitoIdentity: \(self.cognitoIdentity ?? "nil"), clientContext: \(self.clientContext ?? "nil"), deadline: \(self.deadline))"
     }
-
-    /// This interface is not part of the public API and must not be used by adopters. This API is not part of semver versioning.
-    public static func __forTestsOnly(
-        requestID: String,
-        traceID: String,
-        invokedFunctionARN: String,
-        timeout: DispatchTimeInterval,
-        logger: Logger,
-        eventLoop: EventLoop
-    ) -> LambdaContext {
-        LambdaContext(
-            requestID: requestID,
-            traceID: traceID,
-            invokedFunctionARN: invokedFunctionARN,
-            deadline: .now() + timeout,
-            logger: logger,
-            eventLoop: eventLoop,
-            allocator: ByteBufferAllocator()
-        )
-    }
 }

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -53,16 +53,6 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///
     /// - parameters:
-    ///     - request: Event of type `Event` representing the event or request.
-    ///     - context: Runtime ``LambdaContext``.
-    ///
-    /// - Returns: A Lambda result of type `Response`.
-    func handle(request: Request) async throws -> Response
-    
-    /// The Lambda handling method.
-    /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
-    ///
-    /// - parameters:
     ///     - request: Event of type `Request` representing the event or request.
     ///     - context: Runtime ``LambdaContext``.
     ///
@@ -86,10 +76,6 @@ extension LambdaHandler {
             try await Self(context: context)
         }
         return promise.futureResult
-    }
-    
-    public func handle(request: Request, context: LambdaContext) async throws -> Response {
-        try await handle(request: request)
     }
 }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -38,7 +38,7 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
     /// Use this method to initialize resources that will be used in every request.
     ///
     /// Examples for this can be HTTP or database clients.
-    init()
+    init() async throws
     
     /// The Lambda initialization method.
     /// Use this method to initialize resources that will be used in every request. Defaults to
@@ -62,8 +62,12 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension LambdaHandler {
+    public init() async throws {
+        throw LambdaRuntimeError.upstreamError("You should not indirectly initialize LambdaHandlers")
+    }
+    
     public init(context: LambdaInitializationContext) async throws {
-        self.init()
+        try await self.init()
     }
     
     public static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<Self> {

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -27,6 +27,13 @@ import NIOCore
 ///         ``ByteBufferLambdaHandler``.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol LambdaHandler: EventLoopLambdaHandler {
+    /// The lambda functions input. In most cases this should be `Codable`. If your event originates from an
+    /// AWS service, have a look at [AWSLambdaEvents](https://github.com/swift-server/swift-aws-lambda-events),
+    /// which provides a number of commonly used AWS Event implementations.
+    associatedtype Event = Self.Event where Event == Self.Event
+    /// The lambda functions output. Can be `Void`.
+    associatedtype Output = Self.Output where Output == Self.Output
+    
     /// The empty Lambda initialization method.
     /// Use this method to initialize resources that will be used in every request.
     ///

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -62,6 +62,10 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension LambdaHandler {
+    public init() async throws {
+        throw LambdaRuntimeError.upstreamError("You should not indirectly initialize LambdaHandler as an explicit type")
+    }
+
     public init(context: LambdaInitializationContext) async throws {
         try await self.init()
     }
@@ -200,7 +204,8 @@ public protocol ByteBufferLambdaHandler {
     /// If not implemented, this variable has a default value that follows this priority:
     ///
     /// 1. The value of the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable.
-    /// 2. If the env variable isn't found, defaults to `true` if running directly in Xcode.
+    /// 2. If the env variable isn't found, defaults to `true` if running directly in Xcode. If
+    /// running tests in Xcode, this defaults to `false`, instead.
     /// 3. If not running in Xcode and the env variable is missing, defaults to `false`.
     /// 4. No-op on `RELEASE` (production) builds. The AWSLambdaRuntime framework will not compile
     /// any logic accessing this property.

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -56,14 +56,14 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
     ///     - request: Event of type `Event` representing the event or request.
     ///     - context: Runtime ``LambdaContext``.
     ///
-    /// - Returns: A Lambda result ot type `Output`.
+    /// - Returns: A Lambda result of type `Response`.
     func handle(request: Request) async throws -> Response
     
     /// The Lambda handling method.
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///
     /// - parameters:
-    ///     - request: Event of type `Event` representing the event or request.
+    ///     - request: Event of type `Request` representing the event or request.
     ///     - context: Runtime ``LambdaContext``.
     ///
     /// - Returns: A Lambda result ot type `Output`.

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -53,7 +53,17 @@ public protocol LambdaHandler: EventLoopLambdaHandler {
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///
     /// - parameters:
-    ///     - event: Event of type `Event` representing the event or request.
+    ///     - request: Event of type `Event` representing the event or request.
+    ///     - context: Runtime ``LambdaContext``.
+    ///
+    /// - Returns: A Lambda result ot type `Output`.
+    func handle(request: Request) async throws -> Response
+    
+    /// The Lambda handling method.
+    /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
+    ///
+    /// - parameters:
+    ///     - request: Event of type `Event` representing the event or request.
     ///     - context: Runtime ``LambdaContext``.
     ///
     /// - Returns: A Lambda result ot type `Output`.
@@ -76,6 +86,10 @@ extension LambdaHandler {
             try await Self(context: context)
         }
         return promise.futureResult
+    }
+    
+    public func handle(request: Request, context: LambdaContext) async throws -> Response {
+        try await handle(request: request)
     }
 }
 
@@ -139,8 +153,8 @@ public protocol EventLoopLambdaHandler: ByteBufferLambdaHandler {
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///
     /// - parameters:
-    ///     - context: Runtime ``LambdaContext``.
     ///     - event: Event of type `Event` representing the event or request.
+    ///     - context: Runtime ``LambdaContext``.
     ///
     /// - Returns: An `EventLoopFuture` to report the result of the Lambda back to the runtime engine.
     ///            The `EventLoopFuture` should be completed with either a response of type ``Output`` or an `Error`.

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -74,7 +74,7 @@ internal final class LambdaRunner {
                 invocation: invocation
             )
             logger.debug("sending invocation to lambda handler \(handler)")
-            return handler.handle(bytes, context: context)
+            return handler.handle(buffer: bytes, context: context)
                 // Hopping back to "our" EventLoop is important in case the handler returns a future that
                 // originiated from a foreign EventLoop/EventLoopGroup.
                 // This can happen if the handler uses a library (lets say a DB client) that manages its own threads/loops

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -13,13 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-#if compiler(>=5.6)
-@preconcurrency import NIOCore
-@preconcurrency import NIOHTTP1
-#else
 import NIOCore
 import NIOHTTP1
-#endif
 
 /// An HTTP based client for AWS Runtime Engine. This encapsulates the RESTful methods exposed by the Runtime Engine:
 /// * /runtime/invocation/next

--- a/Sources/AWSLambdaRuntimeCore/Terminator.swift
+++ b/Sources/AWSLambdaRuntimeCore/Terminator.swift
@@ -20,11 +20,7 @@ import NIOCore
 public final class LambdaTerminator {
     fileprivate typealias Handler = (EventLoop) -> EventLoopFuture<Void>
 
-    private var storage: Storage
-
-    init() {
-        self.storage = Storage()
-    }
+    private var storage: Storage = Storage()
 
     /// Register a shutdown handler with the terminator.
     ///

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -90,7 +90,7 @@ extension Lambda {
         let handler = try promise.futureResult.wait()
 
         return try eventLoop.flatSubmit {
-            handler.handle(event, context: context)
+            handler.handle(event: event, context: context)
         }.wait()
     }
 }

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -17,11 +17,6 @@
 //
 // func test() {
 //     struct MyLambda: LambdaHandler {
-//         typealias Event = String
-//         typealias Output = String
-//
-//         init(context: Lambda.InitializationContext) {}
-//
 //         func handle(_ event: String, context: LambdaContext) async throws -> String {
 //             "echo" + event
 //         }
@@ -39,6 +34,8 @@ import Dispatch
 import Logging
 import NIOCore
 import NIOPosix
+
+@testable import AWSLambdaRuntimeCore
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Lambda {
@@ -77,13 +74,14 @@ extension Lambda {
             eventLoop: eventLoop
         )
 
-        let context = LambdaContext.__forTestsOnly(
+        let context = LambdaContext(
             requestID: config.requestID,
             traceID: config.traceID,
             invokedFunctionARN: config.invokedFunctionARN,
-            timeout: config.timeout,
+            deadline: .now() + config.timeout,
             logger: logger,
-            eventLoop: eventLoop
+            eventLoop: eventLoop,
+            allocator: ByteBufferAllocator()
         )
 
         promise.completeWithTask {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -18,6 +18,11 @@ import XCTest
 
 class LambdaHandlerTest: XCTestCase {
     #if compiler(>=5.5) && canImport(_Concurrency)
+    
+    override func setUp() {
+        super.setUp()
+        setenv("LOCAL_LAMBDA_SERVER_ENABLED", "false", 1)
+    }
 
     // MARK: - LambdaHandler
 
@@ -58,7 +63,6 @@ class LambdaHandlerTest: XCTestCase {
         struct TestBootstrapHandler: LambdaHandler {
             var initialized = false
 
-            init() {}
             init(context: LambdaInitializationContext) async throws {
                 XCTAssertFalse(self.initialized)
                 try await Task.sleep(nanoseconds: 100 * 1000 * 1000) // 0.1 seconds
@@ -72,6 +76,7 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 10 ... 20)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        
         assertLambdaRuntimeResult(
             try Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self),
             shouldFailWithError: TestError("kaboom")
@@ -146,9 +151,6 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
             static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
@@ -172,9 +174,6 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias Event = String
-            typealias Output = Void
-
             static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
@@ -198,9 +197,6 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
             static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
@@ -224,9 +220,6 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
             static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeFailedFuture(TestError("kaboom"))
             }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -28,11 +28,9 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: LambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
             var initialized = false
 
+            init() {}
             init(context: LambdaInitializationContext) async throws {
                 XCTAssertFalse(self.initialized)
                 try await Task.sleep(nanoseconds: 100 * 1000 * 1000) // 0.1 seconds
@@ -46,8 +44,10 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 10 ... 20)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
-        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self),
+            shouldHaveRun: maxTimes
+        )
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
@@ -57,11 +57,9 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: LambdaHandler {
-            typealias Event = String
-            typealias Output = Void
-
             var initialized = false
 
+            init() {}
             init(context: LambdaInitializationContext) async throws {
                 XCTAssertFalse(self.initialized)
                 try await Task.sleep(nanoseconds: 100 * 1000 * 1000) // 0.1 seconds
@@ -75,8 +73,10 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 10 ... 20)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
-        assertLambdaRuntimeResult(result, shouldFailWithError: TestError("kaboom"))
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self),
+            shouldFailWithError: TestError("kaboom")
+        )
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
@@ -86,11 +86,6 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
-            init(context: LambdaInitializationContext) {}
-
             func handle(_ event: String, context: LambdaContext) async throws -> String {
                 event
             }
@@ -98,8 +93,10 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
-        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: Handler.self),
+            shouldHaveRun: maxTimes
+        )
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
@@ -109,19 +106,16 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias Event = String
-            typealias Output = Void
-
-            init(context: LambdaInitializationContext) {}
-
             func handle(_ event: String, context: LambdaContext) async throws {}
         }
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
 
-        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
-        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: Handler.self),
+            shouldHaveRun: maxTimes
+        )
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
@@ -131,11 +125,6 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
-            init(context: LambdaInitializationContext) {}
-
             func handle(_ event: String, context: LambdaContext) async throws -> String {
                 throw TestError("boom")
             }
@@ -143,8 +132,10 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
-        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: Handler.self),
+            shouldHaveRun: maxTimes
+        )
     }
     #endif
 
@@ -170,8 +161,10 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
-        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: Handler.self),
+            shouldHaveRun: maxTimes
+        )
     }
 
     func testVoidEventLoopSuccess() {
@@ -194,8 +187,10 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
-        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: Handler.self),
+            shouldHaveRun: maxTimes
+        )
     }
 
     func testEventLoopFailure() {
@@ -218,8 +213,10 @@ class LambdaHandlerTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
-        assertLambdaRuntimeResult(result, shoudHaveRun: maxTimes)
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: configuration, handlerType: Handler.self),
+            shouldHaveRun: maxTimes
+        )
     }
 
     func testEventLoopBootstrapFailure() {
@@ -241,8 +238,10 @@ class LambdaHandlerTest: XCTestCase {
             }
         }
 
-        let result = Lambda.run(configuration: .init(), handlerType: Handler.self)
-        assertLambdaRuntimeResult(result, shouldFailWithError: TestError("kaboom"))
+        assertLambdaRuntimeResult(
+            try Lambda.run(configuration: .init(), handlerType: Handler.self),
+            shouldFailWithError: TestError("kaboom")
+        )
     }
 }
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -41,8 +41,8 @@ class LambdaHandlerTest: XCTestCase {
                 self.initialized = true
             }
 
-            func handle(_ event: String, context: LambdaContext) async throws -> String {
-                event
+            func handle(request: String, context: LambdaContext) async throws -> String {
+                request
             }
         }
 
@@ -69,7 +69,7 @@ class LambdaHandlerTest: XCTestCase {
                 throw TestError("kaboom")
             }
 
-            func handle(_ event: String, context: LambdaContext) async throws {
+            func handle(request: String, context: LambdaContext) async throws {
                 XCTFail("How can this be called if init failed")
             }
         }
@@ -90,8 +90,8 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            func handle(_ event: String, context: LambdaContext) async throws -> String {
-                event
+            func handle(request: String, context: LambdaContext) async throws -> String {
+                request
             }
         }
 
@@ -110,7 +110,7 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            func handle(_ event: String, context: LambdaContext) async throws {}
+            func handle(request: String, context: LambdaContext) async throws {}
         }
 
         let maxTimes = Int.random(in: 1 ... 10)
@@ -129,7 +129,7 @@ class LambdaHandlerTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            func handle(_ event: String, context: LambdaContext) async throws -> String {
+            func handle(request: String, context: LambdaContext) async throws -> String {
                 throw TestError("boom")
             }
         }
@@ -155,7 +155,7 @@ class LambdaHandlerTest: XCTestCase {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
-            func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
+            func handle(event: String, context: LambdaContext) -> EventLoopFuture<String> {
                 context.eventLoop.makeSucceededFuture(event)
             }
         }
@@ -178,7 +178,7 @@ class LambdaHandlerTest: XCTestCase {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
-            func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<Void> {
+            func handle(event: String, context: LambdaContext) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
             }
         }
@@ -201,7 +201,7 @@ class LambdaHandlerTest: XCTestCase {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
-            func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
+            func handle(event: String, context: LambdaContext) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }
@@ -224,7 +224,7 @@ class LambdaHandlerTest: XCTestCase {
                 context.eventLoop.makeFailedFuture(TestError("kaboom"))
             }
 
-            func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
+            func handle(event: String, context: LambdaContext) -> EventLoopFuture<String> {
                 XCTFail("Must never be called")
                 return context.eventLoop.makeFailedFuture(TestError("boom"))
             }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -30,7 +30,6 @@ class LambdaHandlerTest: XCTestCase {
         struct TestBootstrapHandler: LambdaHandler {
             var initialized = false
 
-            init() {}
             init(context: LambdaInitializationContext) async throws {
                 XCTAssertFalse(self.initialized)
                 try await Task.sleep(nanoseconds: 100 * 1000 * 1000) // 0.1 seconds

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlers.swift
@@ -17,14 +17,11 @@ import NIOCore
 import XCTest
 
 struct EchoHandler: EventLoopLambdaHandler {
-    typealias Event = String
-    typealias Output = String
-
     static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<EchoHandler> {
         context.eventLoop.makeSucceededFuture(EchoHandler())
     }
 
-    func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
+    func handle(event: String, context: LambdaContext) -> EventLoopFuture<String> {
         context.eventLoop.makeSucceededFuture(event)
     }
 }
@@ -32,14 +29,11 @@ struct EchoHandler: EventLoopLambdaHandler {
 struct StartupError: Error {}
 
 struct StartupErrorHandler: EventLoopLambdaHandler {
-    typealias Event = String
-    typealias Output = String
-
     static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<StartupErrorHandler> {
         context.eventLoop.makeFailedFuture(StartupError())
     }
 
-    func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
+    func handle(event: String, context: LambdaContext) -> EventLoopFuture<String> {
         XCTFail("Must never be called")
         return context.eventLoop.makeSucceededFuture(event)
     }
@@ -48,14 +42,11 @@ struct StartupErrorHandler: EventLoopLambdaHandler {
 struct RuntimeError: Error {}
 
 struct RuntimeErrorHandler: EventLoopLambdaHandler {
-    typealias Event = String
-    typealias Output = Void
-
     static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<RuntimeErrorHandler> {
         context.eventLoop.makeSucceededFuture(RuntimeErrorHandler())
     }
 
-    func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<Void> {
+    func handle(event: String, context: LambdaContext) -> EventLoopFuture<Void> {
         context.eventLoop.makeFailedFuture(RuntimeError())
     }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeTest.swift
@@ -71,9 +71,6 @@ class LambdaRuntimeTest: XCTestCase {
         }
 
         struct ShutdownErrorHandler: EventLoopLambdaHandler {
-            typealias Event = String
-            typealias Output = Void
-
             static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<ShutdownErrorHandler> {
                 // register shutdown operation
                 context.terminator.register(name: "test 1", handler: { eventLoop in
@@ -94,7 +91,7 @@ class LambdaRuntimeTest: XCTestCase {
                 return context.eventLoop.makeSucceededFuture(ShutdownErrorHandler())
             }
 
-            func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<Void> {
+            func handle(event: String, context: LambdaContext) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededVoidFuture()
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -13,13 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 @testable import AWSLambdaRuntimeCore
-#if compiler(>=5.6)
-@preconcurrency import Logging
-@preconcurrency import NIOPosix
-#else
 import Logging
 import NIOPosix
-#endif
 import NIOCore
 import XCTest
 
@@ -108,7 +103,7 @@ class LambdaTest: XCTestCase {
             usleep(100_000)
             kill(getpid(), signal.rawValue)
         }
-        let result = try try Lambda.run(configuration: configuration, handlerType: EchoHandler.self)
+        let result = try Lambda.run(configuration: configuration, handlerType: EchoHandler.self)
         XCTAssertGreaterThan(result, 0, "should have stopped before any request made")
         XCTAssertLessThan(result, maxTimes, "should have stopped before \(maxTimes)")
     }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -95,7 +95,7 @@ class LambdaTest: XCTestCase {
 
         let signal = Signal.ALRM
         let maxTimes = 1000
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes, stopSignal: signal))
+        let configuration = LambdaConfiguration(lifecycle: .init(stopSignal: signal, maxTimes: maxTimes))
 
         DispatchQueue(label: "test").async {
             // we need to schedule the signal before we start the long running `Lambda.run`, since

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -268,14 +268,11 @@ class LambdaTest: XCTestCase {
     #if compiler(>=5.6)
     func testSendable() async throws {
         struct Handler: EventLoopLambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
             static func makeHandler(context: LambdaInitializationContext) -> EventLoopFuture<Handler> {
                 context.eventLoop.makeSucceededFuture(Handler())
             }
 
-            func handle(_ event: String, context: LambdaContext) -> EventLoopFuture<String> {
+            func handle(event: String, context: LambdaContext) -> EventLoopFuture<String> {
                 context.eventLoop.makeSucceededFuture("hello")
             }
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -42,7 +42,7 @@ func assertLambdaRuntimeResult(_ result: @autoclosure () throws -> Int, shouldHa
         }
     } catch {
         if let shouldFailWithError = shouldFailWithError {
-            XCTAssertEqual(String(describing: shouldFailWithError), String(describing: error), "expected error to mactch", file: file, line: line)
+            XCTAssertEqual(String(describing: shouldFailWithError), String(describing: error), "expected error to match", file: file, line: line)
         } else {
             XCTFail("should succeed, but failed with \(error)", file: file, line: line)
         }

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
@@ -94,12 +94,7 @@ class CodableLambdaTest: XCTestCase {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testCodableVoidHandler() {
         struct Handler: LambdaHandler {
-            typealias Event = Request
-            typealias Output = Void
-
             var expected: Request?
-
-            init(context: LambdaInitializationContext) async throws {}
 
             func handle(_ event: Request, context: LambdaContext) async throws {
                 XCTAssertEqual(event, self.expected)
@@ -123,12 +118,7 @@ class CodableLambdaTest: XCTestCase {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testCodableHandler() {
         struct Handler: LambdaHandler {
-            typealias Event = Request
-            typealias Output = Response
-
             var expected: Request?
-
-            init(context: LambdaInitializationContext) async throws {}
 
             func handle(_ event: Request, context: LambdaContext) async throws -> Response {
                 XCTAssertEqual(event, self.expected)

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -30,11 +30,6 @@ class LambdaTestingTests: XCTestCase {
         }
 
         struct MyLambda: LambdaHandler {
-            typealias Event = Request
-            typealias Output = Response
-
-            init(context: LambdaInitializationContext) {}
-
             func handle(_ event: Request, context: LambdaContext) async throws -> Response {
                 Response(message: "echo" + event.name)
             }
@@ -54,11 +49,6 @@ class LambdaTestingTests: XCTestCase {
         }
 
         struct MyLambda: LambdaHandler {
-            typealias Event = Request
-            typealias Output = Void
-
-            init(context: LambdaInitializationContext) {}
-
             func handle(_ event: Request, context: LambdaContext) async throws {
                 LambdaTestingTests.VoidLambdaHandlerInvokeCount += 1
             }
@@ -74,11 +64,6 @@ class LambdaTestingTests: XCTestCase {
         struct MyError: Error {}
 
         struct MyLambda: LambdaHandler {
-            typealias Event = String
-            typealias Output = Void
-
-            init(context: LambdaInitializationContext) {}
-
             func handle(_ event: String, context: LambdaContext) async throws {
                 throw MyError()
             }
@@ -91,11 +76,6 @@ class LambdaTestingTests: XCTestCase {
 
     func testAsyncLongRunning() {
         struct MyLambda: LambdaHandler {
-            typealias Event = String
-            typealias Output = String
-
-            init(context: LambdaInitializationContext) {}
-
             func handle(_ event: String, context: LambdaContext) async throws -> String {
                 try await Task.sleep(nanoseconds: 500 * 1000 * 1000)
                 return event

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -30,8 +30,8 @@ class LambdaTestingTests: XCTestCase {
         }
 
         struct MyLambda: LambdaHandler {
-            func handle(_ event: Request, context: LambdaContext) async throws -> Response {
-                Response(message: "echo" + event.name)
+            func handle(request: Request, context: LambdaContext) async throws -> Response {
+                Response(message: "echo" + request.name)
             }
         }
 
@@ -49,7 +49,7 @@ class LambdaTestingTests: XCTestCase {
         }
 
         struct MyLambda: LambdaHandler {
-            func handle(_ event: Request, context: LambdaContext) async throws {
+            func handle(request: Request, context: LambdaContext) async throws {
                 LambdaTestingTests.VoidLambdaHandlerInvokeCount += 1
             }
         }
@@ -64,7 +64,7 @@ class LambdaTestingTests: XCTestCase {
         struct MyError: Error {}
 
         struct MyLambda: LambdaHandler {
-            func handle(_ event: String, context: LambdaContext) async throws {
+            func handle(request: String, context: LambdaContext) async throws {
                 throw MyError()
             }
         }
@@ -76,9 +76,9 @@ class LambdaTestingTests: XCTestCase {
 
     func testAsyncLongRunning() {
         struct MyLambda: LambdaHandler {
-            func handle(_ event: String, context: LambdaContext) async throws -> String {
+            func handle(request: String, context: LambdaContext) async throws -> String {
                 try await Task.sleep(nanoseconds: 500 * 1000 * 1000)
-                return event
+                return request
             }
         }
 

--- a/readme.md
+++ b/readme.md
@@ -128,11 +128,8 @@ First, add a dependency on the event packages:
 
  // Our Lambda handler, conforms to EventLoopLambdaHandler
  struct Handler: EventLoopLambdaHandler {
-     typealias In = SNS.Message // Request type
-     typealias Out = Void // Response type
-
      // In this example we are receiving an SNS Message, with no response (Void).
-     func handle(context: Lambda.Context, event: In) -> EventLoopFuture<Out> {
+     func handle(event: SNS.Message, context: LambdaContext) -> EventLoopFuture<Void> {
          ...
          context.eventLoop.makeSucceededFuture(Void())
      }

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ import AWSLambdaRuntime
 @main
 struct Handler: LambdaHandler {
     // in this example we are receiving and responding with strings
-    func handle(request: String) -> String {
+    func handle(request: String, context: LambdaContext) -> String {
         "Hello, \(request)!"
     }
 }
@@ -79,7 +79,7 @@ private struct Response: Encodable {
 @main
 struct Handler: LambdaHandler {
     // In this example we are receiving a `Decodable` and responding with an `Encodable`.
-    func handle(request: Request) -> Response {
+    func handle(request: Request, context: LambdaContext) -> Response {
         Response(message: Hello, \(request.name)!")
     }
 }
@@ -122,7 +122,7 @@ import AWSLambdaEvents
 @main
 struct Handler: LambdaHandler {
     // In this example we are receiving a Decodable, with no response (Void).
-    func handle(request: SQS.Event) {
+    func handle(request: SQS.Event, context: LambdaContext) {
         ...
     }
 }


### PR DESCRIPTION
This PR aims to improve developer ergonomics for simple `LambdaHandler` conformances when trying to quickly put together a local server to test against.

### Motivation:

Swift 5.7 added primary associated types for protocols where you can start using generic bracket syntax for protocols. An issue for this was opened not too long ago in this repo (#266) with the primary motivation of improving developer ergonomics around types conforming to `LambdaHander`. However, swift's type inference system _should_ be able to handle the aforementioned issue just fine without using primary associated types (although support for that could still be useful when defining properties conforming to `LambdaHandler` when you want to constrain the types).

Swift's type inference system does not pick up the `Event` and `Output` types for objects conforming to `LambdaHandler` because those types are defined in the covariant protocol `EventLoopLambdaHandler`. This means that you need to add type aliases for `Event` and `Output` when conforming to `LambdaHandler` - resulting in less than ideal developer ergonomics when trying to spin up a quick little local server.

Additionally, the initializer for `LambdaHandler` is currently a required function in the protocol. This is super useful for setup logic for your Handlers but degrades the developer ergonomics of the most simple/minimal use-case for LambdaHandlers. Developers should be able to continue having the capability of writing simple lambda handlers like they could do in 0.5.2:

```swift
import AWSLambdaRuntime
import Foundation

Lambda.run { (context, input: Request, callback: @escaping (Result<String, Error>) -> Void) in
    callback(.success(...))
}
```

The current state of affairs in comparison is to explicitly define the `Event` and `Output` associated types of `LambdaHandler` when writing a simple lambda as well as being forced to include an init that isn't necessarily always required to successfully run a simple lambda:

```swift
import AWSLambdaRuntime
import Foundation

@main
struct EntryHandler: LambdaHandler {
    typealias Event = SomeCodableEventType
    typealias Output = SomeCodableOutputType
   
    init(context: AWSLambdaRuntimeCore.LambdaInitializationContext) async throws {
        // The body of this could be blank and the lambda would still work
    }
   
    func handle(_ event: Event, context: LambdaContext) async throws -> Output {
        // lambda logic
    }
}
```

With the changes on main, a developer loses the ease of writing a three-line lambda that they could do in 0.5.2.

On top of all of this, when needing to run a server locally in Xcode, a developer would need to add an environment variable to their local scheme. This isn't a much used feature in Xcode for developers coming from iOS who are looking to maybe start writing swift on the server. This isn't too big of a deal, but could be a bit of pain to do when trying to set yourself up with Lambda for the first time. It also introduces the possibility of having to manage two different environment variables if you're switching between debugging in Xcode or running the server locally in your Terminal. It would be nice to have the capability of defining this in code so a developer wouldn't have to open a separate window to toggle a server running locally.

I may be wrong about this (not a lot of experience writing swift on the server), but if a developer is running a local server in Xcode, it should be safe to assume that the server isn't running on an environment like AWS Lambda or Docker. I think that if a server is running their Lambda in Xcode, `LOCAL_LAMBDA_SERVER_ENABLED` should be enabled by default. Doing so would enable developers to package ready-to-go example local servers with their example mobile apps (maybe they want to demonstrate the usage of an SDK or something).

Currently, developers in this situation would have to instruct their users to set up this `LOCAL_LAMBDA_SERVER_ENABLED` environment variable. If a user is a swift developer already, they might have the urge to open that Package in Xcode and just hit run without knowing they need to set that variable up. 

With the support of a variable for enabling running as a local server in Lambda directly, a developer could package a ready-to-go local server package with their example apps that would only require opening the package and running in Xcode with no extra set up.

### Modifications:

* Removes ambiguities between `LambdaHandler`, `EventLoopLambdaHandler`, and `ByteBufferLambdaHandler`. The `handle(_:context:)` functions shared across all three prevented the swift compiler from properly inferring the `Event` and `Output` types between `LambdaHandler` and `EventLoopLambdaHandler`. The `handle(_:context:)` functions are now more descriptive with their primary parameter to match the protocol they are associated with:
    * `LambdaHandler.handle(_:context)` has now been changed to `LambdaHandler(request:context:)`
    * `EventLoopLambdaHandler.handle(_:context)` has now been changed to `EventLoopLambdaHandler(event:context:)`
    * `ByteBufferLambdaHandler.handle(_:context)` has now been changed to `ByteBufferLambdaHandler(buffer:context:)`
* Adds an init function to the `LambdaHandler` protocol
    * Adds a default implementation for `init(context:)` that calls through to `init()` - this allows fully qualified structs conforming to `LambdaHandler` to omit their initializers if no setup is required for the Lambda handler
* Adds a static var `isLocalServerEnabled` to the `ByteBufferLambdaHandler` protocol
    * Default is `true` when running in Xcode, but still respects the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable.
    * This defaults to `false` if running outside of Xcode
* Updates tests with new changes 

### Result:

With all of the changes in this PR, a developer could package a local lambda handler Swift Package with an example app that could look like this:

```swift
@main
final class EntryHandler: LambdaHandler {
    func handle(request: YourDecodableRequest, context: LambdaContext) -> YourEncodableResponse {
        // lambda logic
    }
}
```

All previous logic is still retained but the optional code needed is now opt-in with sensible defaults.