### PR TITLE
fix concurrency api usage

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -158,3 +158,6 @@ extension Result {
         }
     }
 }
+
+/// This is safe since lambda runtime synchronizes by dispatching all methods to a single `EventLoop`
+extension LambdaRunner: @unchecked Sendable {}

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -266,7 +266,7 @@ class LambdaTest: XCTestCase {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
 
-        let server = try MockLambdaServer(behavior: Behavior()).start().wait()
+        let server = try await MockLambdaServer(behavior: Behavior()).start().get()
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         let logger = Logger(label: "TestLogger")
@@ -278,17 +278,17 @@ class LambdaTest: XCTestCase {
             logger.info("hello")
             let runner = LambdaRunner(eventLoop: eventLoopGroup.next(), configuration: configuration)
 
-            try runner.run(
+            try await runner.run(
                 handler: CodableEventLoopLambdaHandler(
                     handler: handler1,
                     allocator: ByteBufferAllocator()
                 ),
                 logger: logger
-            ).wait()
+            ).get()
 
-            try runner.initialize(handlerType: CodableEventLoopLambdaHandler<Handler>.self, logger: logger, terminator: LambdaTerminator()).flatMap { handler2 in
+            try await runner.initialize(handlerType: CodableEventLoopLambdaHandler<Handler>.self, logger: logger, terminator: LambdaTerminator()).flatMap { handler2 in
                 runner.run(handler: handler2, logger: logger)
-            }.wait()
+            }.get()
         }
 
         try await task.value

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 # this file is not designed to be run directly
 # instead, use the docker-compose.<os>.<swift> files
-# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.al2.55.yaml run test
+# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.al2.57.yaml run test
 version: "3"
 
 services:


### PR DESCRIPTION
motivation: cleanup incorrect concurent code in test

changes: use .get instead of .wait
