### PR TITLE
Add note about naming the file main.swift to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ First, create a SwiftPM project and pull Swift AWS Lambda Runtime as dependency 
  )
  ```
 
-Next, create a `MyLambda.swift` and implement your Lambda.
+Next, create a `MyLambda.swift` and implement your Lambda. Note that the file can not be named `main.swift` or you will encounter the following error: `'main' attribute cannot be used in a module that contains top-level code`.
 
 ### Using async function
 


### PR DESCRIPTION
This change adds a note about naming the file `main.swift` and using the `@main` attribute.

### Motivation:

When transitioning to the 1.x API users may have had their files named `main.swift` and will encounter the error `'main' attribute cannot be used in a module that contains top-level code`. This change adds a note to help remedy this issue and make it easy to locate when searching the repository.

### Modifications:

- Added note to `readme.md`

### Result:

- Improved documentation.
