### PR TITLE
README.MD SimpleLambdaHandler example with events.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Next, create a `MyLambda.swift` and implement your Lambda. Note that the file ca
  @main
  struct MyLambda: SimpleLambdaHandler {
      // In this example we are receiving a SQS Event, with no response (Void).
-     func handle(_ event: SQS.Event, context: LambdaContext) async throws -> Void {
+     func handle(_ event: SQSEvent, context: LambdaContext) async throws {
          ...
      }
  }


### PR DESCRIPTION
Changed the `SQS.Event` type to the existing `SQSEvent` type

### Motivation:

Try to run the mentioned code snippet throws a *non existing type* error.

Because the AWS events are developed in a separated package could takes some times to find the error to a developer trying to use this snippet as base for his/her code.

Also, the `Void` returning type has been removed from code, following the [Apple style guideline](https://developer.apple.com/documentation/swift/void) related to the use of `Void`.

### Modifications:

At **README.MD** file, change the snippet to use the right type and `Void` returning type removed to follow the Apple style guideline.

### Result:

The snippet 

```swift
 // Import the modules
 import AWSLambdaRuntime
 import AWSLambdaEvents

 @main
 struct MyLambda: SimpleLambdaHandler {
     // In this example we are receiving a SQS Event, with no response (Void).
     func handle(_ event: SQSEvent, context: LambdaContext) async throws {
         ...
     }
 }
```
