### PR TITLE
Archive plugin documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,8 +185,25 @@ To build and package your Lambda, run the following command:
  swift package archive
  ```
 
+The `archive` command can be customized using the following parameters
+
+* `--output-path` A valid file system path where a folder with the archive operation result will be placed. This folder will contains the following elements:
+    * A file link named `bootstrap`
+    * An executable file
+    * A **Zip** file ready to be upload to AWS
+* `--verbose` A number that sets the command output detail level between the following values:
+    * `0` (Silent)
+    * `1` (Output)
+    * `2` (Debug)
+* `--swift-version` Swift language version used to define the Amazon Linux 2 Docker image. For example "5.7.3"
+* `--base-docker-image` An Amazon Linux 2 docker image name available in your system.
+
+Both `--swift-version` and `--base-docker-image` are mutually exclusive
+
  on macOS, the archiving plugin uses docker to build the Lambda for Amazon Linux 2, and as such requires to communicate with Docker over the localhost network.
  At the moment, SwiftPM does not allow plugin communication over network, and as such the invocation requires breaking from the SwiftPM plugin sandbox. This limitation would be removed in the future.
+ 
+ 
 
 ```shell
  swift package --disable-sandbox archive

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,14 @@ The `archive` command can be customized using the following parameters
 
 Both `--swift-version` and `--base-docker-image` are mutually exclusive
 
+Here's an example
+
+```zsh
+swift package archive --output-path /Users/JohnAppleseed/Desktop --verbose 2
+```
+
+This command execution will generate a folder at `/Users/JohnAppleseed/Desktop` with the lambda zipped and ready to upload it and set the command detail output level to `2` (debug)
+
  on macOS, the archiving plugin uses docker to build the Lambda for Amazon Linux 2, and as such requires to communicate with Docker over the localhost network.
  At the moment, SwiftPM does not allow plugin communication over network, and as such the invocation requires breaking from the SwiftPM plugin sandbox. This limitation would be removed in the future.
  


### PR DESCRIPTION
Provide information related to the arguments that the new `archive` command can take.

### Motivation:

The **README.MD** file only mention the new `archive` command, but doesn't mention the arguments that this command can take.

Some of them are really useful, like the `--output-path` or `--swift-version` parameters, and it could be helpful for developers known the different arguments that this plugin provides.

### Modifications:

Added new content to the **Deploying to AWS Lambda** section.

### Result:

There's a new list with the `archive` command arguments and an example of usage.


### Remarks

English is not my mother language (🇪🇸😜) and probably text style could be changed to a more appropriate style. Feel free to let corrections as comments over this PR. 

Thanks 😀
