### PR TITLE
improve examples

### DIFF
--- a/Examples/Benchmark/Package.swift
+++ b/Examples/Benchmark/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -11,10 +12,7 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"]),
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .executableTarget(
@@ -26,3 +24,10 @@ let package = Package(
         ),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/Examples/Deployment/Package.swift
+++ b/Examples/Deployment/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -15,10 +16,7 @@ let package = Package(
         // demonstrate different types of error handling
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .executableTarget(name: "Benchmark", dependencies: [
@@ -29,3 +27,10 @@ let package = Package(
         ]),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/Examples/Echo/Package.swift
+++ b/Examples/Echo/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -11,10 +12,7 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"]),
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .executableTarget(
@@ -26,3 +24,10 @@ let package = Package(
         ),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/Examples/ErrorHandling/Package.swift
+++ b/Examples/ErrorHandling/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -11,10 +12,7 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"]),
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .executableTarget(
@@ -26,3 +24,10 @@ let package = Package(
         ),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/Examples/Foundation/Package.swift
+++ b/Examples/Foundation/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -11,10 +12,7 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"]),
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .executableTarget(
@@ -26,3 +24,10 @@ let package = Package(
         ),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/Examples/JSON/Package.swift
+++ b/Examples/JSON/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -11,10 +12,7 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"]),
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .executableTarget(
@@ -26,3 +24,10 @@ let package = Package(
         ),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/Examples/LocalDebugging/MyLambda/Package.swift
+++ b/Examples/LocalDebugging/MyLambda/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -11,10 +12,7 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"]),
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
         .package(name: "Shared", path: "../Shared"),
     ],
     targets: [
@@ -24,7 +22,16 @@ let package = Package(
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
                 .product(name: "Shared", package: "Shared"),
             ],
-            path: "."
+            path: ".",
+            exclude: ["scripts/", "Dockerfile"]
         ),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../../.."),
+        .package(name: "Shared", path: "../Shared"),
+    ]
+}

--- a/Examples/Testing/Package.swift
+++ b/Examples/Testing/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.7
 
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
 import PackageDescription
 
 let package = Package(
@@ -11,10 +12,7 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"]),
     ],
     dependencies: [
-        // this is the dependency on the swift-aws-lambda-runtime library
-        // in real-world projects this would say
-        // .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0")
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .executableTarget(
@@ -28,3 +26,10 @@ let package = Package(
         .testTarget(name: "MyLambdaTests", dependencies: ["MyLambda"], path: "Tests"),
     ]
 )
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/docker/docker-compose.al2.57.yaml
+++ b/docker/docker-compose.al2.57.yaml
@@ -11,7 +11,7 @@ services:
   test:
     image: swift-aws-lambda:al2-5.7
 
-  test-samples:
+  test-examples:
     image: swift-aws-lambda:al2-5.7
 
   shell:

--- a/docker/docker-compose.al2.58.yaml
+++ b/docker/docker-compose.al2.58.yaml
@@ -11,7 +11,7 @@ services:
   test:
     image: swift-aws-lambda:al2-5.8
 
-  test-samples:
+  test-examples:
     image: swift-aws-lambda:al2-5.8
 
   shell:

--- a/docker/docker-compose.al2.main.yaml
+++ b/docker/docker-compose.al2.main.yaml
@@ -11,7 +11,7 @@ services:
   test:
     image: swift-aws-lambda:al2-main
 
-  test-samples:
+  test-examples:
     image: swift-aws-lambda:al2-main
 
   shell:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -30,21 +30,6 @@ services:
     <<: *common
     command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
 
-  # to be deprecated, sue test-examples instead
-  test-samples:
-    <<: *common
-    command: >-
-      /bin/bash -clx "
-      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Benchmark &&
-      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Deployment &&
-      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Echo &&
-      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/ErrorHandling &&
-      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Foundation &&
-      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/JSON &&
-      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/LocalDebugging/MyLambda &&
-      LAMBDA_USE_LOCAL_DEPS=true swift test --package-path Examples/Testing
-      "
-
   test-examples:
     <<: *common
     command: >-

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -30,18 +30,33 @@ services:
     <<: *common
     command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
 
+  # to be deprecated, sue test-examples instead
   test-samples:
     <<: *common
     command: >-
       /bin/bash -clx "
-      swift build --package-path Examples/Benchmark &&
-      swift build --package-path Examples/Deployment &&
-      swift build --package-path Examples/Echo &&
-      swift build --package-path Examples/ErrorHandling &&
-      swift build --package-path Examples/Foundation &&
-      swift build --package-path Examples/JSON &&
-      swift build --package-path Examples/LocalDebugging/MyLambda  &&
-      swift test --package-path Examples/Testing
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Benchmark &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Deployment &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Echo &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/ErrorHandling &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Foundation &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/JSON &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/LocalDebugging/MyLambda &&
+      LAMBDA_USE_LOCAL_DEPS=true swift test --package-path Examples/Testing
+      "
+
+  test-examples:
+    <<: *common
+    command: >-
+      /bin/bash -clx "
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Benchmark &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Deployment &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Echo &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/ErrorHandling &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/Foundation &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/JSON &&
+      LAMBDA_USE_LOCAL_DEPS=true swift build --package-path Examples/LocalDebugging/MyLambda &&
+      LAMBDA_USE_LOCAL_DEPS=true swift test --package-path Examples/Testing
       "
 
   # util


### PR DESCRIPTION
motivation: examples can be confusing since they use relative path to the library for CI purposes

changes:
* update examples to use the library URL, expect when env variable is set for CI purposes
* rename docker compose job to test-examples since it is more accurate
