### PR TITLE
Fix: link to getting started in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Swift AWS Lambda Runtime was designed to make building Lambda functions in Swift
 
 ## Getting started
 
-If you have never used AWS Lambda or Docker before, check out this [getting started guide](https://fabianfett.de/getting-started-with-swift-aws-lambda-runtime) which helps you with every step from zero to a running Lambda.
+If you have never used AWS Lambda or Docker before, check out this [getting started guide](https://fabianfett.dev/getting-started-with-swift-aws-lambda-runtime) which helps you with every step from zero to a running Lambda.
 
 First, create a SwiftPM project and pull Swift AWS Lambda Runtime as dependency into your project
 


### PR DESCRIPTION
Fix the URL to the Getting Started guide in the README

### Motivation:

I clicked on the link and it didn't work.

### Modifications:

I changed `.de` to the correct `.dev`

### Result:

The link works now.