### PR TITLE
remove swift-backtrace in swift >= 5.9

### DIFF
--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -23,6 +23,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.43.1")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
+        .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.2.3")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
@@ -33,6 +34,7 @@ let package = Package(
         ]),
         .target(name: "AWSLambdaRuntimeCore", dependencies: [
             .product(name: "Logging", package: "swift-log"),
+            .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOCore", package: "swift-nio"),
             .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -23,6 +23,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.43.1")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
+        .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.2.3")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
@@ -33,6 +34,7 @@ let package = Package(
         ]),
         .target(name: "AWSLambdaRuntimeCore", dependencies: [
             .product(name: "Logging", package: "swift-log"),
+            .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOCore", package: "swift-nio"),
             .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -18,7 +18,9 @@ import Glibc
 import Darwin.C
 #endif
 
+#if swift(<5.9)
 import Backtrace
+#endif
 import Logging
 import NIOCore
 import NIOPosix
@@ -85,7 +87,9 @@ public enum Lambda {
         handlerType: (some ByteBufferLambdaHandler).Type
     ) -> Result<Int, Error> {
         let _run = { (configuration: LambdaConfiguration) -> Result<Int, Error> in
+            #if swift(<5.9)
             Backtrace.install()
+            #endif
             var logger = Logger(label: "Lambda")
             logger.logLevel = configuration.general.logLevel
 


### PR DESCRIPTION
motivation: swift 5.9 ships with builtin backtrace support \o/

changes:
* remove the dependency on swift-backtrace when using swift 5.9 or above
* conditionalize the call to Backtrace.install to relevant versions only
