### PR TITLE
ignore swift files part of docc

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -130,6 +130,7 @@ EOF
     find . \
       \( \! -path '*/.build/*' -a \
       \( \! -path '*/.git/*' \) -a \
+      \( \! -path '*/Documentation.docc/*' \) -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
       if [[ "$(cat "$line" | replace_acceptable_years | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then


### PR DESCRIPTION
Ignore swift files part of docc

### Motivation:

Fix for issue https://github.com/swift-server/swift-aws-lambda-runtime/issues/306


### Modifications:

`scripts/soundness.sh` ignores `.swift` files in the `Documentation.docc` directories.

### Result:

Swift code snippets that are part of the `Documentation.docc` directory are not required to have a license header.
