### PR TITLE
Allow custom initialisation of the HandlerType of the LambdaRuntime.

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -19,10 +19,10 @@ import class Foundation.JSONEncoder
 import NIOCore
 import NIOFoundationCompat
 
-// MARK: - SimpleLambdaHandler Codable support
+// MARK: - NonFactoryLambdaHandler Codable support
 
 /// Implementation of `ByteBuffer` to `Event` decoding.
-extension SimpleLambdaHandler where Event: Decodable {
+extension NonFactoryLambdaHandler where Event: Decodable {
     @inlinable
     public func decode(buffer: ByteBuffer) throws -> Event {
         try self.decoder.decode(Event.self, from: buffer)
@@ -30,7 +30,7 @@ extension SimpleLambdaHandler where Event: Decodable {
 }
 
 /// Implementation of `Output` to `ByteBuffer` encoding.
-extension SimpleLambdaHandler where Output: Encodable {
+extension NonFactoryLambdaHandler where Output: Encodable {
     @inlinable
     public func encode(value: Output, into buffer: inout ByteBuffer) throws {
         try self.encoder.encode(value, into: &buffer)
@@ -39,7 +39,7 @@ extension SimpleLambdaHandler where Output: Encodable {
 
 /// Default `ByteBuffer` to `Event` decoder using Foundation's `JSONDecoder`.
 /// Advanced users who want to inject their own codec can do it by overriding these functions.
-extension SimpleLambdaHandler where Event: Decodable {
+extension NonFactoryLambdaHandler where Event: Decodable {
     public var decoder: LambdaCodableDecoder {
         Lambda.defaultJSONDecoder
     }
@@ -47,41 +47,7 @@ extension SimpleLambdaHandler where Event: Decodable {
 
 /// Default `Output` to `ByteBuffer` encoder using Foundation's `JSONEncoder`.
 /// Advanced users who want to inject their own codec can do it by overriding these functions.
-extension SimpleLambdaHandler where Output: Encodable {
-    public var encoder: LambdaCodableEncoder {
-        Lambda.defaultJSONEncoder
-    }
-}
-
-// MARK: - LambdaHandler Codable support
-
-/// Implementation of `ByteBuffer` to `Event` decoding.
-extension LambdaHandler where Event: Decodable {
-    @inlinable
-    public func decode(buffer: ByteBuffer) throws -> Event {
-        try self.decoder.decode(Event.self, from: buffer)
-    }
-}
-
-/// Implementation of `Output` to `ByteBuffer` encoding.
-extension LambdaHandler where Output: Encodable {
-    @inlinable
-    public func encode(value: Output, into buffer: inout ByteBuffer) throws {
-        try self.encoder.encode(value, into: &buffer)
-    }
-}
-
-/// Default `ByteBuffer` to `Event` decoder using Foundation's `JSONDecoder`.
-/// Advanced users who want to inject their own codec can do it by overriding these functions.
-extension LambdaHandler where Event: Decodable {
-    public var decoder: LambdaCodableDecoder {
-        Lambda.defaultJSONDecoder
-    }
-}
-
-/// Default `Output` to `ByteBuffer` encoder using Foundation's `JSONEncoder`.
-/// Advanced users who want to inject their own codec can do it by overriding these functions.
-extension LambdaHandler where Output: Encodable {
+extension NonFactoryLambdaHandler where Output: Encodable {
     public var encoder: LambdaCodableEncoder {
         Lambda.defaultJSONEncoder
     }

--- a/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda+String.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-// MARK: - SimpleLambdaHandler String support
+// MARK: - NonFactoryLambdaHandler String support
 
-extension SimpleLambdaHandler where Event == String {
+extension NonFactoryLambdaHandler where Event == String {
     /// Implementation of a `ByteBuffer` to `String` decoding.
     @inlinable
     public func decode(buffer: ByteBuffer) throws -> Event {
@@ -26,28 +26,7 @@ extension SimpleLambdaHandler where Event == String {
     }
 }
 
-extension SimpleLambdaHandler where Output == String {
-    /// Implementation of `String` to `ByteBuffer` encoding.
-    @inlinable
-    public func encode(value: Output, into buffer: inout ByteBuffer) throws {
-        buffer.writeString(value)
-    }
-}
-
-// MARK: - LambdaHandler String support
-
-extension LambdaHandler where Event == String {
-    /// Implementation of a `ByteBuffer` to `String` decoding.
-    @inlinable
-    public func decode(buffer: ByteBuffer) throws -> Event {
-        guard let value = buffer.getString(at: buffer.readerIndex, length: buffer.readableBytes) else {
-            throw CodecError.invalidString
-        }
-        return value
-    }
-}
-
-extension LambdaHandler where Output == String {
+extension NonFactoryLambdaHandler where Output == String {
     /// Implementation of `String` to `ByteBuffer` encoding.
     @inlinable
     public func encode(value: Output, into buffer: inout ByteBuffer) throws {

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -36,7 +36,7 @@ public enum Lambda {
         configuration: LambdaConfiguration = .init(),
         handlerType: Handler.Type
     ) -> Result<Int, Error> {
-        Self.run(configuration: configuration, handlerProvider: CodableSimpleLambdaHandler<Handler>.makeHandler)
+        Self.run(configuration: configuration, handlerProvider: Handler.makeCodableHandler)
     }
 
     /// Run a Lambda defined by implementing the ``LambdaHandler`` protocol.
@@ -52,7 +52,7 @@ public enum Lambda {
         configuration: LambdaConfiguration = .init(),
         handlerType: Handler.Type
     ) -> Result<Int, Error> {
-        Self.run(configuration: configuration, handlerProvider: CodableLambdaHandler<Handler>.makeHandler)
+        Self.run(configuration: configuration, handlerProvider: Handler.makeCodableHandler)
     }
 
     /// Run a Lambda defined by implementing the ``EventLoopLambdaHandler`` protocol.
@@ -82,7 +82,7 @@ public enum Lambda {
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     internal static func run(
         configuration: LambdaConfiguration = .init(),
-        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some CoreByteBufferLambdaHandler>
+        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some NonFactoryByteBufferLambdaHandler>
     ) -> Result<Int, Error> {
         let _run = { (configuration: LambdaConfiguration) -> Result<Int, Error> in
             Backtrace.install()

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -122,9 +122,9 @@ internal struct UncheckedSendableHandler<Underlying: LambdaHandler, Event, Outpu
 /// ``LambdaHandler/Event`` and returns a user defined
 /// ``LambdaHandler/Output`` asynchronously.
 ///
-/// - note: Most users should implement this protocol instead of the lower
-///         level protocols ``EventLoopLambdaHandler`` and
-///         ``ByteBufferLambdaHandler``.
+/// Unlike the `LambdaHandler` and `SimpleLambdaHandler` protocols,
+/// this does not have any initialization requirement, allowing it to be used - along with
+/// the `NonFactoryByteBufferLambdaHandler` protocol with custom initialization.
 public protocol NonFactoryLambdaHandler {
     /// The lambda function's input. In most cases this should be `Codable`. If your event originates from an
     /// AWS service, have a look at [AWSLambdaEvents](https://github.com/swift-server/swift-aws-lambda-events),
@@ -163,6 +163,8 @@ public protocol NonFactoryLambdaHandler {
 }
 
 public extension NonFactoryLambdaHandler {
+    /// Creates a `NonFactoryByteBufferLambdaHandler` from the current instance that will handle
+    /// Codable serialization and deserialization.
     func withWrappingCodableHandler(allocator: ByteBufferAllocator) -> some NonFactoryByteBufferLambdaHandler {
         return NonFactoryCodableLambdaHandler(handler: self, allocator: allocator)
     }
@@ -337,7 +339,7 @@ extension EventLoopLambdaHandler {
 
 /// An `EventLoopFuture` based processing protocol for a Lambda that takes a `ByteBuffer` and returns
 /// an optional `ByteBuffer` asynchronously. Unlike the higher level `ByteBufferLambdaHandler` protocol,
-/// this protocol doesn't provide a factory method for creating an instance of itself.
+/// this doesn't provide a factory method for creating an instance of itself.
 ///
 /// - note: This is a low level protocol designed designed for use cases where the flexibility of the
 ///         `LambdaRuntime` type is required directly. Applications can provide the runtime with a

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -33,9 +33,9 @@ internal final class LambdaRunner {
     /// Run the user provided initializer. This *must* only be called once.
     ///
     /// - Returns: An `EventLoopFuture<LambdaHandler>` fulfilled with the outcome of the initialization.
-    func initialize<Handler: CoreByteBufferLambdaHandler>(handlerProvider: (LambdaInitializationContext) -> EventLoopFuture<Handler>,
-                                                          logger: Logger,
-                                                          terminator: LambdaTerminator) -> EventLoopFuture<Handler> {
+    func initialize<Handler: NonFactoryByteBufferLambdaHandler>(handlerProvider: (LambdaInitializationContext) -> EventLoopFuture<Handler>,
+                                                                logger: Logger,
+                                                                terminator: LambdaTerminator) -> EventLoopFuture<Handler> {
         logger.debug("initializing lambda")
         // 1. create the handler from the factory
         // 2. report initialization error if one occurred
@@ -61,7 +61,7 @@ internal final class LambdaRunner {
             }
     }
 
-    func run(handler: some CoreByteBufferLambdaHandler, logger: Logger) -> EventLoopFuture<Void> {
+    func run(handler: some NonFactoryByteBufferLambdaHandler, logger: Logger) -> EventLoopFuture<Void> {
         logger.debug("lambda invocation sequence starting")
         // 1. request invocation from lambda runtime engine
         self.isGettingNextInvocation = true

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -19,7 +19,7 @@ import NIOCore
 /// `LambdaRuntime` manages the Lambda process lifecycle.
 ///
 /// Use this API, if you build a higher level web framework which shall be able to run inside the Lambda environment.
-public final class LambdaRuntime<Handler: CoreByteBufferLambdaHandler> {
+public final class LambdaRuntime<Handler: NonFactoryByteBufferLambdaHandler> {
     private let eventLoop: EventLoop
     private let shutdownPromise: EventLoopPromise<Int>
     private let logger: Logger
@@ -179,7 +179,7 @@ public final class LambdaRuntime<Handler: CoreByteBufferLambdaHandler> {
     private enum State {
         case idle
         case initializing
-        case active(LambdaRunner, any CoreByteBufferLambdaHandler)
+        case active(LambdaRunner, any NonFactoryByteBufferLambdaHandler)
         case shuttingdown
         case shutdown
 
@@ -208,9 +208,9 @@ public enum LambdaRuntimeFactory {
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
     @inlinable
-    public static func makeRuntime<H: SimpleLambdaHandler>(_ handlerType: H.Type, eventLoop: any EventLoop, logger: Logger) -> LambdaRuntime<some ByteBufferLambdaHandler> {
-        LambdaRuntime<CodableSimpleLambdaHandler<H>>(handlerProvider: CodableSimpleLambdaHandler<H>.makeHandler,
-                                                     eventLoop: eventLoop, logger: logger)
+    public static func makeRuntime<H: SimpleLambdaHandler>(_ handlerType: H.Type, eventLoop: any EventLoop, logger: Logger) -> LambdaRuntime<some NonFactoryByteBufferLambdaHandler> {
+        LambdaRuntime<NonFactoryCodableLambdaHandler<H>>(handlerProvider: H.makeCodableHandler,
+                                                         eventLoop: eventLoop, logger: logger)
     }
 
     /// Create a new `LambdaRuntime`.
@@ -220,9 +220,9 @@ public enum LambdaRuntimeFactory {
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
     @inlinable
-    public static func makeRuntime<H: LambdaHandler>(_ handlerType: H.Type, eventLoop: any EventLoop, logger: Logger) -> LambdaRuntime<some ByteBufferLambdaHandler> {
-        LambdaRuntime<CodableLambdaHandler<H>>(handlerProvider: CodableLambdaHandler<H>.makeHandler,
-                                               eventLoop: eventLoop, logger: logger)
+    public static func makeRuntime<H: LambdaHandler>(_ handlerType: H.Type, eventLoop: any EventLoop, logger: Logger) -> LambdaRuntime<some NonFactoryByteBufferLambdaHandler> {
+        LambdaRuntime<NonFactoryCodableLambdaHandler<H>>(handlerProvider: H.makeCodableHandler,
+                                                         eventLoop: eventLoop, logger: logger)
     }
 
     /// Create a new `LambdaRuntime`.

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -286,7 +286,7 @@ class LambdaTest: XCTestCase {
                 logger: logger
             ).get()
 
-            try await runner.initialize(handlerType: CodableEventLoopLambdaHandler<Handler>.self, logger: logger, terminator: LambdaTerminator()).flatMap { handler2 in
+            try await runner.initialize(handlerProvider: CodableEventLoopLambdaHandler<Handler>.makeHandler, logger: logger, terminator: LambdaTerminator()).flatMap { handler2 in
                 runner.run(handler: handler2, logger: logger)
             }.get()
         }

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -19,11 +19,11 @@ import NIOPosix
 import XCTest
 
 func runLambda<Handler: SimpleLambdaHandler>(behavior: LambdaServerBehavior, handlerType: Handler.Type) throws {
-    try runLambda(behavior: behavior, handlerProvider: CodableSimpleLambdaHandler<Handler>.makeHandler)
+    try runLambda(behavior: behavior, handlerProvider: Handler.makeCodableHandler)
 }
 
 func runLambda<Handler: LambdaHandler>(behavior: LambdaServerBehavior, handlerType: Handler.Type) throws {
-    try runLambda(behavior: behavior, handlerProvider: CodableLambdaHandler<Handler>.makeHandler)
+    try runLambda(behavior: behavior, handlerProvider: Handler.makeCodableHandler)
 }
 
 func runLambda<Handler: EventLoopLambdaHandler>(behavior: LambdaServerBehavior, handlerType: Handler.Type) throws {
@@ -31,7 +31,7 @@ func runLambda<Handler: EventLoopLambdaHandler>(behavior: LambdaServerBehavior, 
 }
 
 func runLambda(behavior: LambdaServerBehavior,
-               handlerProvider: (LambdaInitializationContext) -> EventLoopFuture<some CoreByteBufferLambdaHandler>) throws {
+               handlerProvider: (LambdaInitializationContext) -> EventLoopFuture<some NonFactoryByteBufferLambdaHandler>) throws {
     let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
     let logger = Logger(label: "TestLogger")

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodableTest.swift
@@ -108,7 +108,7 @@ class CodableLambdaTest: XCTestCase {
 
         var underlying = try await Handler(context: self.newInitContext())
         underlying.expected = request
-        let handler = CodableLambdaHandler(
+        let handler = NonFactoryCodableLambdaHandler(
             handler: underlying,
             allocator: context.allocator
         )
@@ -138,64 +138,7 @@ class CodableLambdaTest: XCTestCase {
 
         var underlying = try await Handler(context: self.newInitContext())
         underlying.expected = request
-        let handler = CodableLambdaHandler(
-            handler: underlying,
-            allocator: context.allocator
-        )
-
-        var inputBuffer = context.allocator.buffer(capacity: 1024)
-        XCTAssertNoThrow(try JSONEncoder().encode(request, into: &inputBuffer))
-
-        var outputBuffer: ByteBuffer?
-        XCTAssertNoThrow(outputBuffer = try handler.handle(inputBuffer, context: context).wait())
-        XCTAssertNoThrow(response = try JSONDecoder().decode(Response.self, from: XCTUnwrap(outputBuffer)))
-        XCTAssertNoThrow(try handler.handle(inputBuffer, context: context).wait())
-        XCTAssertEqual(response?.requestId, request.requestId)
-    }
-
-    func testCodableVoidSimpleHandler() async throws {
-        struct Handler: SimpleLambdaHandler {
-            var expected: Request?
-
-            func handle(_ event: Request, context: LambdaContext) async throws {
-                XCTAssertEqual(event, self.expected)
-            }
-        }
-
-        let context = self.newContext()
-        let request = Request(requestId: UUID().uuidString)
-
-        var underlying = Handler()
-        underlying.expected = request
-        let handler = CodableSimpleLambdaHandler(
-            handler: underlying,
-            allocator: context.allocator
-        )
-
-        var inputBuffer = context.allocator.buffer(capacity: 1024)
-        XCTAssertNoThrow(try JSONEncoder().encode(request, into: &inputBuffer))
-        var outputBuffer: ByteBuffer?
-        XCTAssertNoThrow(outputBuffer = try handler.handle(inputBuffer, context: context).wait())
-        XCTAssertEqual(outputBuffer?.readableBytes, 0)
-    }
-
-    func testCodableSimpleHandler() async throws {
-        struct Handler: SimpleLambdaHandler {
-            var expected: Request?
-
-            func handle(_ event: Request, context: LambdaContext) async throws -> Response {
-                XCTAssertEqual(event, self.expected)
-                return Response(requestId: event.requestId)
-            }
-        }
-
-        let context = self.newContext()
-        let request = Request(requestId: UUID().uuidString)
-        var response: Response?
-
-        var underlying = Handler()
-        underlying.expected = request
-        let handler = CodableSimpleLambdaHandler(
+        let handler = NonFactoryCodableLambdaHandler(
             handler: underlying,
             allocator: context.allocator
         )


### PR DESCRIPTION
Allow custom initialisation of the HandlerType of the LambdaRuntime.

### Motivation:

Provide the flexibility for custom initialisation of the HandlerType as this will often be required by higher level frameworks.

### Modifications:

Modify the `LambdaRuntime` type to accept a closure to provide the handler rather than requiring that it is provided by a static method on the Handler type. This is achieved by a new base protocol `NonFactoryByteBufferLambdaHandler` that does not have the `makeHandler` function requirement.

Also provide a new base protocol `NonFactoryLambdaHandler` that doesn't have the initialisation requirements of either `LambdaHandler` or `SimpleLambdaHandler`. This will allow higher level frameworks to initialise their own handlers that however can take advantage of the `Codable` conveniences of this package.

```swift
@Sendable
func handlerProvider(context: LambdaInitializationContext) 
-> EventLoopFuture<some NonFactoryByteBufferLambdaHandler> {
    let underlyingHandler = <initialise a type conforming to NonFactoryLambdaHandler>
    let codableHandler = underlyingHandler.withWrappingCodableHandler(allocator: context.allocator)

    return context.eventLoop.makeSuceededFuture(codableHandler)
}
```

### Result:

Existing high level use cases (`LambdaHandler` and `SimpleLambdaHandler`) will continue to be provided but a lower level integration will be possible aimed at higher level frameworks.
