### PR TITLE
allow custom initialization of the HandlerType of the LambdaRuntime

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -89,18 +89,15 @@ public enum Lambda {
         Self.run(configuration: configuration, handlerProvider: handlerType.makeHandler(context:))
     }
 
-    /// Run a Lambda defined by implementing the ``ByteBufferLambdaHandler`` protocol.
-    /// The Runtime will manage the Lambdas application lifecycle automatically. It will invoke the
-    /// ``ByteBufferLambdaHandler/makeHandler(context:)`` to create a new Handler.
-    ///
+    /// Run a Lambda defined by implementing the ``LambdaRuntimeHandler`` protocol.
     /// - parameters:
     ///     - configuration: A Lambda runtime configuration object
-    ///     - handlerProvider: A provider of the Handler to invoke.
+    ///     - handlerProvider: A provider of the ``LambdaRuntimeHandler``` to invoke.
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     internal static func run(
         configuration: LambdaConfiguration = .init(),
-        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some NonInitializingByteBufferLambdaHandler>
+        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some LambdaRuntimeHandler>
     ) -> Result<Int, Error> {
         let _run = { (configuration: LambdaConfiguration) -> Result<Int, Error> in
             #if swift(<5.9)

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -92,7 +92,7 @@ public enum Lambda {
     /// Run a Lambda defined by implementing the ``LambdaRuntimeHandler`` protocol.
     /// - parameters:
     ///     - configuration: A Lambda runtime configuration object
-    ///     - handlerProvider: A provider of the ``LambdaRuntimeHandler``` to invoke.
+    ///     - handlerProvider: A provider of the ``LambdaRuntimeHandler`` to invoke.
     ///
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     internal static func run(

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -100,7 +100,7 @@ public enum Lambda {
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     internal static func run(
         configuration: LambdaConfiguration = .init(),
-        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some CoreByteBufferLambdaHandler>
+        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some NonInitializingByteBufferLambdaHandler>
     ) -> Result<Int, Error> {
         let _run = { (configuration: LambdaConfiguration) -> Result<Int, Error> in
             #if swift(<5.9)

--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -38,7 +38,7 @@ public enum Lambda {
         configuration: LambdaConfiguration = .init(),
         handlerType: Handler.Type
     ) -> Result<Int, Error> {
-        Self.run(configuration: configuration, handlerType: CodableSimpleLambdaHandler<Handler>.self)
+        Self.run(configuration: configuration, handlerProvider: CodableSimpleLambdaHandler<Handler>.makeHandler(context:))
     }
 
     /// Run a Lambda defined by implementing the ``LambdaHandler`` protocol.
@@ -54,7 +54,7 @@ public enum Lambda {
         configuration: LambdaConfiguration = .init(),
         handlerType: Handler.Type
     ) -> Result<Int, Error> {
-        Self.run(configuration: configuration, handlerType: CodableLambdaHandler<Handler>.self)
+        Self.run(configuration: configuration, handlerProvider: CodableLambdaHandler<Handler>.makeHandler(context:))
     }
 
     /// Run a Lambda defined by implementing the ``EventLoopLambdaHandler`` protocol.
@@ -70,7 +70,7 @@ public enum Lambda {
         configuration: LambdaConfiguration = .init(),
         handlerType: Handler.Type
     ) -> Result<Int, Error> {
-        Self.run(configuration: configuration, handlerType: CodableEventLoopLambdaHandler<Handler>.self)
+        Self.run(configuration: configuration, handlerProvider: CodableEventLoopLambdaHandler<Handler>.makeHandler(context:))
     }
 
     /// Run a Lambda defined by implementing the ``ByteBufferLambdaHandler`` protocol.
@@ -100,7 +100,7 @@ public enum Lambda {
     /// - note: This is a blocking operation that will run forever, as its lifecycle is managed by the AWS Lambda Runtime Engine.
     internal static func run(
         configuration: LambdaConfiguration = .init(),
-        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some ByteBufferLambdaHandler>
+        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<some CoreByteBufferLambdaHandler>
     ) -> Result<Int, Error> {
         let _run = { (configuration: LambdaConfiguration) -> Result<Int, Error> in
             #if swift(<5.9)

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -398,7 +398,7 @@ extension EventLoopLambdaHandler {
 /// - note: This is a low level protocol designed to power the higher level ``EventLoopLambdaHandler`` and
 ///         ``LambdaHandler`` based APIs.
 ///         Most users are not expected to use this protocol.
-public protocol ByteBufferLambdaHandler {
+public protocol ByteBufferLambdaHandler: CoreByteBufferLambdaHandler {
     /// Create a Lambda handler for the runtime.
     ///
     /// Use this to initialize all your resources that you want to cache between invocations. This could be database
@@ -431,6 +431,21 @@ extension ByteBufferLambdaHandler {
     public static func main() {
         _ = Lambda.run(configuration: .init(), handlerType: Self.self)
     }
+}
+
+// MARK: - FIXME
+
+public protocol CoreByteBufferLambdaHandler {
+    /// The Lambda handling method.
+    /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
+    ///
+    /// - parameters:
+    ///     - context: Runtime ``LambdaContext``.
+    ///     - event: The event or input payload encoded as `ByteBuffer`.
+    ///
+    /// - Returns: An `EventLoopFuture` to report the result of the Lambda back to the runtime engine.
+    ///            The `EventLoopFuture` should be completed with either a response encoded as `ByteBuffer` or an `Error`.
+    func handle(_ buffer: ByteBuffer, context: LambdaContext) -> EventLoopFuture<ByteBuffer?>
 }
 
 // MARK: - Other

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -398,7 +398,7 @@ extension EventLoopLambdaHandler {
 /// - note: This is a low level protocol designed to power the higher level ``EventLoopLambdaHandler`` and
 ///         ``LambdaHandler`` based APIs.
 ///         Most users are not expected to use this protocol.
-public protocol ByteBufferLambdaHandler: NonInitializingByteBufferLambdaHandler {
+public protocol ByteBufferLambdaHandler: LambdaRuntimeHandler {
     /// Create a Lambda handler for the runtime.
     ///
     /// Use this to initialize all your resources that you want to cache between invocations. This could be database
@@ -433,16 +433,16 @@ extension ByteBufferLambdaHandler {
     }
 }
 
-// MARK: - NonInitializingByteBufferLambdaHandler
+// MARK: - LambdaRuntimeHandler
 
 /// An `EventLoopFuture` based processing protocol for a Lambda that takes a `ByteBuffer` and returns
 /// an optional `ByteBuffer` asynchronously.
 ///
-/// - note: This is a low level protocol designed to enable use cases where a frameworks initializes the 
-///         runtime with a handler outside the normal initialization of 
+/// - note: This is a low level protocol designed to enable use cases where a frameworks initializes the
+///         runtime with a handler outside the normal initialization of
 ///         ``ByteBufferLambdaHandler``, ``EventLoopLambdaHandler`` and ``LambdaHandler`` based APIs.
 ///         Most users are not expected to use this protocol.
-public protocol NonInitializingByteBufferLambdaHandler {
+public protocol LambdaRuntimeHandler {
     /// The Lambda handling method.
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///

--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -398,7 +398,7 @@ extension EventLoopLambdaHandler {
 /// - note: This is a low level protocol designed to power the higher level ``EventLoopLambdaHandler`` and
 ///         ``LambdaHandler`` based APIs.
 ///         Most users are not expected to use this protocol.
-public protocol ByteBufferLambdaHandler: CoreByteBufferLambdaHandler {
+public protocol ByteBufferLambdaHandler: NonInitializingByteBufferLambdaHandler {
     /// Create a Lambda handler for the runtime.
     ///
     /// Use this to initialize all your resources that you want to cache between invocations. This could be database
@@ -433,9 +433,16 @@ extension ByteBufferLambdaHandler {
     }
 }
 
-// MARK: - FIXME
+// MARK: - NonInitializingByteBufferLambdaHandler
 
-public protocol CoreByteBufferLambdaHandler {
+/// An `EventLoopFuture` based processing protocol for a Lambda that takes a `ByteBuffer` and returns
+/// an optional `ByteBuffer` asynchronously.
+///
+/// - note: This is a low level protocol designed to enable use cases where a frameworks initializes the 
+///         runtime with a handler outside the normal initialization of 
+///         ``ByteBufferLambdaHandler``, ``EventLoopLambdaHandler`` and ``LambdaHandler`` based APIs.
+///         Most users are not expected to use this protocol.
+public protocol NonInitializingByteBufferLambdaHandler {
     /// The Lambda handling method.
     /// Concrete Lambda handlers implement this method to provide the Lambda functionality.
     ///

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -33,7 +33,7 @@ internal final class LambdaRunner {
     /// Run the user provided initializer. This *must* only be called once.
     ///
     /// - Returns: An `EventLoopFuture<LambdaHandler>` fulfilled with the outcome of the initialization.
-    func initialize<Handler: CoreByteBufferLambdaHandler>(
+    func initialize<Handler: NonInitializingByteBufferLambdaHandler>(
         handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<Handler>,
         logger: Logger,
         terminator: LambdaTerminator
@@ -63,7 +63,7 @@ internal final class LambdaRunner {
             }
     }
 
-    func run(handler: some CoreByteBufferLambdaHandler, logger: Logger) -> EventLoopFuture<Void> {
+    func run(handler: some NonInitializingByteBufferLambdaHandler, logger: Logger) -> EventLoopFuture<Void> {
         logger.debug("lambda invocation sequence starting")
         // 1. request invocation from lambda runtime engine
         self.isGettingNextInvocation = true

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -33,7 +33,11 @@ internal final class LambdaRunner {
     /// Run the user provided initializer. This *must* only be called once.
     ///
     /// - Returns: An `EventLoopFuture<LambdaHandler>` fulfilled with the outcome of the initialization.
-    func initialize<Handler: ByteBufferLambdaHandler>(handlerType: Handler.Type, logger: Logger, terminator: LambdaTerminator) -> EventLoopFuture<Handler> {
+    func initialize<Handler: ByteBufferLambdaHandler>(
+        handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<Handler>,
+        logger: Logger,
+        terminator: LambdaTerminator
+    ) -> EventLoopFuture<Handler> {
         logger.debug("initializing lambda")
         // 1. create the handler from the factory
         // 2. report initialization error if one occurred
@@ -44,7 +48,7 @@ internal final class LambdaRunner {
             terminator: terminator
         )
 
-        return handlerType.makeHandler(context: context)
+        return handlerProvider(context)
             // Hopping back to "our" EventLoop is important in case the factory returns a future
             // that originated from a foreign EventLoop/EventLoopGroup.
             // This can happen if the factory uses a library (let's say a database client) that manages its own threads/loops

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -33,7 +33,7 @@ internal final class LambdaRunner {
     /// Run the user provided initializer. This *must* only be called once.
     ///
     /// - Returns: An `EventLoopFuture<LambdaHandler>` fulfilled with the outcome of the initialization.
-    func initialize<Handler: NonInitializingByteBufferLambdaHandler>(
+    func initialize<Handler: LambdaRuntimeHandler>(
         handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<Handler>,
         logger: Logger,
         terminator: LambdaTerminator
@@ -63,7 +63,7 @@ internal final class LambdaRunner {
             }
     }
 
-    func run(handler: some NonInitializingByteBufferLambdaHandler, logger: Logger) -> EventLoopFuture<Void> {
+    func run(handler: some LambdaRuntimeHandler, logger: Logger) -> EventLoopFuture<Void> {
         logger.debug("lambda invocation sequence starting")
         // 1. request invocation from lambda runtime engine
         self.isGettingNextInvocation = true

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -33,7 +33,7 @@ internal final class LambdaRunner {
     /// Run the user provided initializer. This *must* only be called once.
     ///
     /// - Returns: An `EventLoopFuture<LambdaHandler>` fulfilled with the outcome of the initialization.
-    func initialize<Handler: ByteBufferLambdaHandler>(
+    func initialize<Handler: CoreByteBufferLambdaHandler>(
         handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<Handler>,
         logger: Logger,
         terminator: LambdaTerminator
@@ -63,7 +63,7 @@ internal final class LambdaRunner {
             }
     }
 
-    func run(handler: some ByteBufferLambdaHandler, logger: Logger) -> EventLoopFuture<Void> {
+    func run(handler: some CoreByteBufferLambdaHandler, logger: Logger) -> EventLoopFuture<Void> {
         logger.debug("lambda invocation sequence starting")
         // 1. request invocation from lambda runtime engine
         self.isGettingNextInvocation = true

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -19,7 +19,7 @@ import NIOCore
 /// `LambdaRuntime` manages the Lambda process lifecycle.
 ///
 /// Use this API, if you build a higher level web framework which shall be able to run inside the Lambda environment.
-public final class LambdaRuntime<Handler: NonInitializingByteBufferLambdaHandler> {
+public final class LambdaRuntime<Handler: LambdaRuntimeHandler> {
     private let eventLoop: EventLoop
     private let shutdownPromise: EventLoopPromise<Int>
     private let logger: Logger
@@ -37,7 +37,7 @@ public final class LambdaRuntime<Handler: NonInitializingByteBufferLambdaHandler
     /// Create a new `LambdaRuntime`.
     ///
     /// - parameters:
-    ///     - handlerProvider: A provider of the ``ByteBufferLambdaHandler``  the `LambdaRuntime` will manage.
+    ///     - handlerProvider: A provider of the ``Handler`` the `LambdaRuntime` will manage.
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
     @usableFromInline
@@ -57,7 +57,7 @@ public final class LambdaRuntime<Handler: NonInitializingByteBufferLambdaHandler
     /// Create a new `LambdaRuntime`.
     ///
     /// - parameters:
-    ///     - handlerProvider: A provider of the ``ByteBufferLambdaHandler``  the `LambdaRuntime` will manage.
+    ///     - handlerProvider: A provider of the ``Handler`` the `LambdaRuntime` will manage.
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
     init(
@@ -200,7 +200,7 @@ public final class LambdaRuntime<Handler: NonInitializingByteBufferLambdaHandler
     private enum State {
         case idle
         case initializing
-        case active(LambdaRunner, any NonInitializingByteBufferLambdaHandler)
+        case active(LambdaRunner, any LambdaRuntimeHandler)
         case shuttingdown
         case shutdown
 
@@ -252,7 +252,7 @@ public enum LambdaRuntimeFactory {
         _ handlerType: Handler.Type,
         eventLoop: any EventLoop,
         logger: Logger
-    ) -> LambdaRuntime<some NonInitializingByteBufferLambdaHandler> {
+    ) -> LambdaRuntime<some LambdaRuntimeHandler> {
         LambdaRuntime<CodableLambdaHandler<Handler>>(
             handlerProvider: CodableLambdaHandler<Handler>.makeHandler(context:),
             eventLoop: eventLoop,
@@ -271,7 +271,7 @@ public enum LambdaRuntimeFactory {
         _ handlerType: Handler.Type,
         eventLoop: any EventLoop,
         logger: Logger
-    ) -> LambdaRuntime<some NonInitializingByteBufferLambdaHandler> {
+    ) -> LambdaRuntime<some LambdaRuntimeHandler> {
         LambdaRuntime<CodableEventLoopLambdaHandler<Handler>>(
             handlerProvider: CodableEventLoopLambdaHandler<Handler>.makeHandler(context:),
             eventLoop: eventLoop,
@@ -290,7 +290,7 @@ public enum LambdaRuntimeFactory {
         _ handlerType: Handler.Type,
         eventLoop: any EventLoop,
         logger: Logger
-    ) -> LambdaRuntime<some NonInitializingByteBufferLambdaHandler> {
+    ) -> LambdaRuntime<some LambdaRuntimeHandler> {
         LambdaRuntime<Handler>(
             handlerProvider: Handler.makeHandler(context:),
             eventLoop: eventLoop,
@@ -301,11 +301,11 @@ public enum LambdaRuntimeFactory {
     /// Create a new `LambdaRuntime`.
     ///
     /// - parameters:
-    ///     - handlerProvider: A provider of the ``CoreByteBufferLambdaHandler``  the `LambdaRuntime` will manage.
+    ///     - handlerProvider: A provider of the ``Handler`` the `LambdaRuntime` will manage.
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
     @inlinable
-    public static func makeRuntime<Handler: NonInitializingByteBufferLambdaHandler>(
+    public static func makeRuntime<Handler: LambdaRuntimeHandler>(
         handlerProvider: @escaping (LambdaInitializationContext) -> EventLoopFuture<Handler>,
         eventLoop: any EventLoop,
         logger: Logger
@@ -320,16 +320,16 @@ public enum LambdaRuntimeFactory {
     /// Create a new `LambdaRuntime`.
     ///
     /// - parameters:
-    ///     - handlerProvider: A provider of the ``CoreByteBufferLambdaHandler``  the `LambdaRuntime` will manage.
+    ///     - handlerProvider: A provider of the ``Handler`` the `LambdaRuntime` will manage.
     ///     - eventLoop: An `EventLoop` to run the Lambda on.
     ///     - logger: A `Logger` to log the Lambda events.
     @inlinable
-    public static func makeRuntime<Handler: NonInitializingByteBufferLambdaHandler>(
+    public static func makeRuntime<Handler: LambdaRuntimeHandler>(
         handlerProvider: @escaping (LambdaInitializationContext) async throws -> Handler,
         eventLoop: any EventLoop,
         logger: Logger
     ) -> LambdaRuntime<Handler> {
-        return LambdaRuntime(
+        LambdaRuntime(
             handlerProvider: { context in
                 let promise = eventLoop.makePromise(of: Handler.self)
                 promise.completeWithTask {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import AWSLambdaRuntimeCore
+import NIOCore
 import XCTest
 
 class LambdaRunnerTest: XCTestCase {
@@ -67,5 +68,67 @@ class LambdaRunnerTest: XCTestCase {
             }
         }
         XCTAssertNoThrow(try runLambda(behavior: Behavior(), handlerType: RuntimeErrorHandler.self))
+    }
+
+    func testCustomProviderSuccess() {
+        struct Behavior: LambdaServerBehavior {
+            let requestId = UUID().uuidString
+            let event = "hello"
+            func getInvocation() -> GetInvocationResult {
+                .success((self.requestId, self.event))
+            }
+
+            func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {
+                XCTAssertEqual(self.requestId, requestId, "expecting requestId to match")
+                XCTAssertEqual(self.event, response, "expecting response to match")
+                return .success(())
+            }
+
+            func processError(requestId: String, error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTFail("should not report error")
+                return .failure(.internalServerError)
+            }
+
+            func processInitError(error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTFail("should not report init error")
+                return .failure(.internalServerError)
+            }
+        }
+        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handlerProvider: { context in
+            context.eventLoop.makeSucceededFuture(EchoHandler())
+        }))
+    }
+
+    func testCustomProviderFailure() {
+        struct Behavior: LambdaServerBehavior {
+            let requestId = UUID().uuidString
+            let event = "hello"
+            func getInvocation() -> GetInvocationResult {
+                .success((self.requestId, self.event))
+            }
+
+            func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {
+                XCTFail("should not report processing")
+                return .failure(.internalServerError)
+            }
+
+            func processError(requestId: String, error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTFail("should not report error")
+                return .failure(.internalServerError)
+            }
+
+            func processInitError(error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTAssertEqual(String(describing: CustomError()), error.errorMessage, "expecting error to match")
+                return .success(())
+            }
+        }
+
+        struct CustomError: Error {}
+
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerProvider: { context -> EventLoopFuture<EchoHandler> in
+            context.eventLoop.makeFailedFuture(CustomError())
+        })) { error in
+            XCTAssertNotNil(error as? CustomError, "expecting error to match")
+        }
     }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
@@ -131,4 +131,66 @@ class LambdaRunnerTest: XCTestCase {
             XCTAssertNotNil(error as? CustomError, "expecting error to match")
         }
     }
+
+    func testCustomAsyncProviderSuccess() {
+        struct Behavior: LambdaServerBehavior {
+            let requestId = UUID().uuidString
+            let event = "hello"
+            func getInvocation() -> GetInvocationResult {
+                .success((self.requestId, self.event))
+            }
+
+            func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {
+                XCTAssertEqual(self.requestId, requestId, "expecting requestId to match")
+                XCTAssertEqual(self.event, response, "expecting response to match")
+                return .success(())
+            }
+
+            func processError(requestId: String, error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTFail("should not report error")
+                return .failure(.internalServerError)
+            }
+
+            func processInitError(error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTFail("should not report init error")
+                return .failure(.internalServerError)
+            }
+        }
+        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handlerProvider: { context async throws -> EchoHandler in
+            EchoHandler()
+        }))
+    }
+
+    func testCustomAsyncProviderFailure() {
+        struct Behavior: LambdaServerBehavior {
+            let requestId = UUID().uuidString
+            let event = "hello"
+            func getInvocation() -> GetInvocationResult {
+                .success((self.requestId, self.event))
+            }
+
+            func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {
+                XCTFail("should not report processing")
+                return .failure(.internalServerError)
+            }
+
+            func processError(requestId: String, error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTFail("should not report error")
+                return .failure(.internalServerError)
+            }
+
+            func processInitError(error: ErrorResponse) -> Result<Void, ProcessErrorError> {
+                XCTAssertEqual(String(describing: CustomError()), error.errorMessage, "expecting error to match")
+                return .success(())
+            }
+        }
+
+        struct CustomError: Error {}
+
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerProvider: { context async throws -> EchoHandler in
+            throw CustomError()
+        })) { error in
+            XCTAssertNotNil(error as? CustomError, "expecting error to match")
+        }
+    }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRunnerTest.swift
@@ -156,7 +156,7 @@ class LambdaRunnerTest: XCTestCase {
                 return .failure(.internalServerError)
             }
         }
-        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handlerProvider: { context async throws -> EchoHandler in
+        XCTAssertNoThrow(try runLambda(behavior: Behavior(), handlerProvider: { _ async throws -> EchoHandler in
             EchoHandler()
         }))
     }
@@ -187,7 +187,7 @@ class LambdaRunnerTest: XCTestCase {
 
         struct CustomError: Error {}
 
-        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerProvider: { context async throws -> EchoHandler in
+        XCTAssertThrowsError(try runLambda(behavior: Behavior(), handlerProvider: { _ async throws -> EchoHandler in
             throw CustomError()
         })) { error in
             XCTAssertNotNil(error as? CustomError, "expecting error to match")


### PR DESCRIPTION
Motivation:  Provide the flexibility for custom initialization of the HandlerType as this will often be required by higher level frameworks.

Modifications:
* Modify the LambdaRuntime type to accept a closure to provide the handler rather than requiring that it is provided by a static method on the Handler type
* Update downstream code to use HandlerProvider
* Update upstream code to support passing Hanlder Type of Handler Provider
* Add and update tests

Originally suggested and coded by @tachyonics in https://github.com/swift-server/swift-aws-lambda-runtime/pull/308