### PR TITLE
Add `--disable-docker-image-update` plugin flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,7 @@ The `archive` command can be customized using the following parameters
     * `2` (Debug)
 * `--swift-version` Swift language version used to define the Amazon Linux 2 Docker image. For example "5.7.3"
 * `--base-docker-image` An Amazon Linux 2 docker image name available in your system.
+* `--disable-docker-image-update` If flag is set, docker image will not be updated and local image will be used.
 
 Both `--swift-version` and `--base-docker-image` are mutually exclusive
 


### PR DESCRIPTION
The `--disable-docker-image-update` plugin flag has be added to allow use of local docker images.

### Motivation:

Sometimes, you need to use a customized local docker image _(ie. you want to use [AWS SDK for Swift](https://github.com/awslabs/aws-sdk-swift) and OpenSSL is required)_. In this case, `docker pull` mustn't to be called.

Until now, the plugin automatically called `docker pull` to update Docker image. With the new flag, Docker image update can be disabled.

### Modifications:

* add `--disable-docker-image-update` plugin flag to disable `docker pull` call

### Result:

I have a local docker image based on Swift 5.9.1 + Amazon Linux 2 and including OpenSSL.

```Dockerfile
FROM swift:5.9.1-amazonlinux2

# Install OpenSSL
RUN yum -y update && yum install -y \
    openssl \
    openssl-devel
```

I have build it with this command:

```bash
docker build -t swift-with-openssl .
```

Now, it's time to archive. Here are the results with or without the new flag.

#### Without flag:

😭 It fails with an error.

```bash

swift package archive --output-path /my/output/path --disable-sandbox --base-docker-image swift-with-openssl
# ...
-------------------------------------------------------------------------
building "my-awesome-lambda" in docker
-------------------------------------------------------------------------
updating "swift-with-openssl" docker image
  Using default tag: latest
  Error response from daemon: pull access denied for swift-with-openssl, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
error: /usr/local/bin/docker pull swift-with-openssl failed with code 1

```

#### With flag:

😁 Everything works as expected.

```bash

swift package archive --output-path /my/output/path --disable-sandbox --base-docker-image swift-with-openssl --disable-docker-image-update
# ...
-------------------------------------------------------------------------
building "my-awesome-lambda" in docker
-------------------------------------------------------------------------
building "MyAwesomeLambda"
  [0/1] Planning build
  Building for production...
# ...
  Build complete! (145.13s)
-------------------------------------------------------------------------
archiving "MyAwesomeLambda"
-------------------------------------------------------------------------
1 archive created
  * MyAwesomeLambda at /my/output/path/MyAwesomeLambda/MyAwesomeLambda.zip
```