### PR TITLE
remove redundant pre-concurrency flag

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -12,7 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(<5.9)
 @preconcurrency import Dispatch
+#else
+import Dispatch
+#endif
+
 import Logging
 import NIOCore
 


### PR DESCRIPTION
motivation: address warnings

changes: remove pre-concurrency flag when not longer needed
