### PR TITLE
Add tracing of request events + mention LOG_LEVEL in README

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -74,6 +74,7 @@ internal final class LambdaRunner {
                 allocator: self.allocator,
                 invocation: invocation
             )
+            logger.trace("Request", metadata: ["bytes": .string(String(buffer: bytes))])
             logger.debug("sending invocation to lambda handler")
             return handler.handle(bytes, context: context)
                 // Hopping back to "our" EventLoop is important in case the handler returns a future that

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -78,8 +78,13 @@ internal final class LambdaRunner {
                 allocator: self.allocator,
                 invocation: invocation
             )
-            logger.trace("Request", metadata: ["bytes": .string(String(buffer: bytes))])
-            logger.debug("sending invocation to lambda handler")
+            // when log level is trace or lower, print the first Kb of the payload
+            if logger.logLevel <= .trace, let buffer = bytes.getSlice(at: 0, length: max(bytes.readableBytes, 1024)) {
+                logger.trace("sending invocation to lambda handler",
+                             metadata: ["1024 first bytes": .string(String(buffer: buffer))])
+            } else {
+                logger.debug("sending invocation to lambda handler")
+            }
             return handler.handle(bytes, context: context)
                 // Hopping back to "our" EventLoop is important in case the handler returns a future that
                 // originated from a foreign EventLoop/EventLoopGroup.

--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@ Before deploying your code to AWS Lambda, you can test it locally by setting the
 LOCAL_LAMBDA_SERVER_ENABLED=true swift run
 ```
 
-This starts a local HTTP endpoint listening on port TCP 7000.  Your can invoke your code by sending an HTTP POST command to `http://127.0.0.1:7000/invoke`.
+This starts a local HTTP server listening on port 7000. You can invoke your local Lambda function by sending an HTTP POST request to `http://127.0.0.1:7000/invoke`.
 
 For example:
 

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ Next, create a `MyLambda.swift` and implement your Lambda. Note that the file ca
 
  Beyond the small cognitive complexity of using the `EventLoopFuture` based APIs, note these APIs should be used with extra care. An `EventLoopLambdaHandler` will execute the user code on the same `EventLoop` (thread) as the library, making processing faster but requiring the user code to never call blocking APIs as it might prevent the underlying process from functioning.
 
-## Testing locally
+## Testing Locally
 
 Before to deploy your code to AWS Lambda, you can test it locally with the command:
 

--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,45 @@ Next, create a `MyLambda.swift` and implement your Lambda. Note that the file ca
 
  Beyond the small cognitive complexity of using the `EventLoopFuture` based APIs, note these APIs should be used with extra care. An `EventLoopLambdaHandler` will execute the user code on the same `EventLoop` (thread) as the library, making processing faster but requiring the user code to never call blocking APIs as it might prevent the underlying process from functioning.
 
+## Testing locally
+
+Before to deploy your code to AWS Lambda, you can test it locally with the command:
+
+```sh
+LOCAL_LAMBDA_SERVER_ENABLED=true swift run
+```
+
+This starts a local HTTP endpoint listening on port TCP 7000.  Your can invoke your code by sending an HTTP POST command to `http://127.0.0.1:7000/invoke`.
+
+For example:
+
+```sh
+curl -v --header "Content-Type:\ application/json" --data @events/create-session.json http://127.0.0.1:7000/invoke
+*   Trying 127.0.0.1:7000...
+* Connected to 127.0.0.1 (127.0.0.1) port 7000
+> POST /invoke HTTP/1.1
+> Host: 127.0.0.1:7000
+> User-Agent: curl/8.4.0
+> Accept: */*
+> Content-Type:\ application/json
+> Content-Length: 1160
+> 
+< HTTP/1.1 200 OK
+< content-length: 247
+< 
+* Connection #0 to host 127.0.0.1 left intact
+{"statusCode":200,"isBase64Encoded":false,"body":"...","headers":{"Access-Control-Allow-Origin":"*","Content-Type":"application\/json; charset=utf-8","Access-Control-Allow-Headers":"*"}}
+```
+
+## Increase logging verbosity 
+
+You can increase the verbosity of the runtime by changing the LOG_LEVEL environment variable.
+
+- `LOG_LEVEL=debug` displays information about the Swift AWS Lambda Runtime activity and lifecycle
+- `LOG_LEVEL=trace` displays a string representation of the input event as received from the AWS Lambda service (before invoking your handler).
+
+You can use the `LOG_LEVEL` environment variable both during your local testing (`LOG_LEVEL=trace LOCAL_LAMBDA_SERVER_ENABLED=true swift run`) or when you deploy your code on AWS Lambda. You can define [environment variables for your Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html) in the AWS console or programmatically.
+
 ## Deploying to AWS Lambda
 
 To deploy Lambda functions to AWS Lambda, you need to compile the code for Amazon Linux which is the OS used on AWS Lambda microVMs, package it as a Zip file, and upload to AWS.

--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,9 @@ LOCAL_LAMBDA_SERVER_ENABLED=true swift run
 
 This starts a local HTTP server listening on port 7000. You can invoke your local Lambda function by sending an HTTP POST request to `http://127.0.0.1:7000/invoke`.
 
-For example:
+The request must include the JSON payload expected as an `Event` by your function. You can create a text file with the JSON payload documented by AWS or captured from a trace.  In this example, we used [the APIGatewayv2 JSON payload from the documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#apigateway-example-event), saved as `events/create-session.json` text file.
+
+Then we use curl to invoke the local endpoint with the test JSON payload.
 
 ```sh
 curl -v --header "Content-Type:\ application/json" --data @events/create-session.json http://127.0.0.1:7000/invoke
@@ -211,7 +213,10 @@ You can increase the verbosity of the runtime using the `LOG_LEVEL` environment 
 - `LOG_LEVEL=debug` displays information about the Swift AWS Lambda Runtime activity and lifecycle
 - `LOG_LEVEL=trace` displays a string representation of the input event as received from the AWS Lambda service (before invoking your handler).
 
-You can use the `LOG_LEVEL` environment variable both during your local testing (`LOG_LEVEL=trace LOCAL_LAMBDA_SERVER_ENABLED=true swift run`) or when you deploy your code on AWS Lambda. You can define [environment variables for your Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html) in the AWS console or programmatically.
+You can modify the verbosity of a Lambda function by passing the LOG_LEVEL environment variable both during your local testing (LOG_LEVEL=trace LOCAL_LAMBDA_SERVER_ENABLED=true swift run) or when you deploy your code on AWS Lambda.
+You can [define environment variables for your Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html) in the AWS console or programmatically.
+
+This repository follows [Swift's Log Level Guidelines](https://www.swift.org/server/guides/libraries/log-levels.html). At `LOG_LEVEL=trace`, the AWS Lambda runtime will display a string representation of the input event as received from the AWS Lambda service before invoking your handler, for maximum debuggability.
 
 ## Deploying to AWS Lambda
 

--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,7 @@ curl -v --header "Content-Type:\ application/json" --data @events/create-session
 
 ## Increase logging verbosity 
 
-You can increase the verbosity of the runtime by changing the LOG_LEVEL environment variable.
+You can increase the verbosity of the runtime using the `LOG_LEVEL` environment variable.
 
 - `LOG_LEVEL=debug` displays information about the Swift AWS Lambda Runtime activity and lifecycle
 - `LOG_LEVEL=trace` displays a string representation of the input event as received from the AWS Lambda service (before invoking your handler).

--- a/readme.md
+++ b/readme.md
@@ -176,7 +176,7 @@ Next, create a `MyLambda.swift` and implement your Lambda. Note that the file ca
 
 ## Testing Locally
 
-Before to deploy your code to AWS Lambda, you can test it locally with the command:
+Before deploying your code to AWS Lambda, you can test it locally by setting the `LOCAL_LAMBDA_SERVER_ENABLED` environment variable to true. It will look like this on CLI:
 
 ```sh
 LOCAL_LAMBDA_SERVER_ENABLED=true swift run


### PR DESCRIPTION
This PR adds a `logger.trace()` in `LambdaRuntime` just before calling user's handler. 
It allows to see in the trace logs a string representation of the event passed by the AWS Service.

### Motivation:

When there is no or poor documentation of the event passed to a lambda function, is it super hard to figure out the exact `Codable` struct to implement for the `LambdaHandler`.

With other programming languages, such as Python or Typescript, developers typically add a `print(event)` or `console.log(event)` at the start of the lambda handler function to figure out the exact type of data to deal with.

When using the Swift AWS Lambda Runtime, it's not possible because the bytes received are encoded to a `struct` before the user's code is called.

When there is a mismatch between the received bytes and the `Codable` struct, the user is left with very few information to figure out what was wrong.  The `encode()` error messages are cryptic. They don't provide enough information to debug this type of error.

### Modifications:

I added one line in `LambdaRuntime` to trace a string representation of the request before calling the user's handler.

```swift
            logger.trace("Request", metadata: ["bytes": .string(String(buffer: bytes))])
```

I also modified the README to document the use of the LOG_LEVEL environemnt variable.
While I was modifying the README, I noticed there was no mention of local test, I therefore added a small section about local testing (which is a subject related to this PR, hence a single PR for the two new sections in the README) 



### Result:

When invoking the runtime with `LOG_LEVEL=trace`, we receive information such as 

```sh
Build complete! (15.97s)
2023-12-16T18:43:33-0500 info LocalLambdaServer : [AWSLambdaRuntimeCore] LocalLambdaServer started and listening on 127.0.0.1:7000, receiving events on /invoke
2023-12-16T18:43:33-0500 info Lambda : [AWSLambdaRuntimeCore] lambda runtime starting with LambdaConfiguration
  General(logLevel: trace))
  Lifecycle(id: 345519645762583, maxTimes: 0, stopSignal: TERM)
  RuntimeEngine(ip: 127.0.0.1, port: 7000, requestTimeout: nil
2023-12-16T18:43:33-0500 debug Lambda : lifecycleId=345519645762583 [AWSLambdaRuntimeCore] initializing lambda
2023-12-16T18:43:33-0500 debug Lambda : lifecycleIteration=0 [AWSLambdaRuntimeCore] lambda invocation sequence starting
2023-12-16T18:43:33-0500 debug Lambda : lifecycleIteration=0 [AWSLambdaRuntimeCore] requesting work from lambda runtime engine using /2018-06-01/runtime/invocation/next
2023-12-16T18:44:18-0500 debug Lambda : lifecycleIteration=0 [AWSLambdaRuntimeCore] sending invocation to lambda handler
2023-12-16T18:44:18-0500 trace Lambda : bytes={	"rawQueryString": "",	"headers": {		"host": "b2k1t8fon7.execute-api.us-east-1.amazonaws.com",	"x-forwarded-port": "443",		"content-length": "0",		"x-amzn-trace-id": "Root=1-6571d134-63dbe8ee21efa87555d59265",		"x-forwarded-for": "191.95.148.219",		"x-forwarded-proto": "https",		"accept": "*/*",		"user-agent": "curl/8.1.2"	},	"requestContext": {		"apiId": "b2k1t8fon7",		"http": {			"sourceIp": "191.95.148.219",			"userAgent": "curl/8.1.2",	"method": "POST",			"path": "/liveness/create",			"protocol": "HTTP/1.1"		},		"timeEpoch": 1701957940365,		"domainPrefix": "b2k1t8fon7",		"accountId": "012345678912",		"time": "07/Dec/2023:14:05:40 +0000",		"stage": "$default",		"domainName": "b2k1t8fon7.execute-api.us-east-1.amazonaws.com",		"requestId": "Pk2gOia2IAMEPOw=",		"authorizer": {		"iam": {				"accessKey": "ASIA-redacted",				"accountId": "012345678912",				"callerId": "AIDA-redacted",				"cognitoIdentity": null,				"principalOrgId": "aws:PrincipalOrgID",				"userArn": "arn:aws:iam::012345678912:user/sst",				"userId": "AIDA-redacted"			}		}	},	"isBase64Encoded": false,	"version": "2.0",	"routeKey": "$default",	"rawPath": "/liveness/create"} lifecycleIteration=0 [AWSLambdaRuntimeCore] Request
2023-12-16T18:44:21-0500 debug Lambda : lifecycleIteration=0 [AWSLambdaRuntimeCore] reporting results to lambda runtime engine using /2018-06-01/runtime/invocation/345564850687750/response
2023-12-16T18:44:21-0500 debug Lambda : lifecycleIteration=0 [AWSLambdaRuntimeCore] lambda invocation sequence completed successfully
2023-12-16T18:44:21-0500 debug Lambda : lifecycleIteration=1 [AWSLambdaRuntimeCore] lambda invocation sequence starting
2023-12-16T18:44:21-0500 debug Lambda : lifecycleIteration=1 [AWSLambdaRuntimeCore] requesting work from lambda runtime engine using /2018-06-01/runtime/invocation/next
```
