### PR TITLE
[plugin] Feature: Build docker image

### DIFF
--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -105,8 +105,8 @@ struct AWSLambdaPackager: CommandPlugin {
         if buildDockerImage {
             try self.execute(
               executable: dockerToolPath.removingLastComponent().appending(subpath: "docker-buildx"),
-              arguments: ["--platform=\(buildDockerImagePlatform)", ".", "-t", baseImage],
-              logLevel: .debug
+              arguments: ["build", "--platform=\(buildDockerImagePlatform)", ".", "-t", baseImage],
+              logLevel: verboseLogging ? .debug : .output
             )
         }
 

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -98,6 +98,12 @@ struct AWSLambdaPackager: CommandPlugin {
             )
         }
 
+      try self.execute(
+        executable: dockerToolPath.removingLastComponent().appending(subpath: "docker-buildx"),
+        arguments: ["build", "--platform=linux/arm64", ".", "-t", baseImage],
+        logLevel: .debug
+      )
+
         // get the build output path
         let buildOutputPathCommand = "swift build -c \(buildConfiguration.rawValue) --show-bin-path"
         let dockerBuildOutputPath = try self.execute(


### PR DESCRIPTION
# Add option to PackagePlugin, to build image before building Lambda package

### Motivation:

I have a Swift Lambda that has dependencies that require the base docker image to have openssl-dev installed. The default implementation did not work for me - I must have missed something somewhere. Therefore I added another optional step to the packaging plugin to also build the image before the compilation step.

### Modifications:

Added two flags, `--build-docker-image` and `--docker-image-platform`, which when set will run an additional build step using `docker-buildx` and use the `Dockerfile` in the project root to build the image


### Result:

When additional arguments are passed to `swift package archive` and a Dockerfile is present, the plugin will build the image before compiling the Lambda
