### PR TITLE
fixed typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,7 +187,7 @@ To build and package your Lambda, run the following command:
 
 The `archive` command can be customized using the following parameters
 
-* `--output-path` A valid file system path where a folder with the archive operation result will be placed. This folder will contains the following elements:
+* `--output-path` A valid file system path where a folder with the archive operation result will be placed. This folder will contain the following elements:
     * A file link named `bootstrap`
     * An executable file
     * A **Zip** file ready to be upload to AWS

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ The `archive` command can be customized using the following parameters
 * `--output-path` A valid file system path where a folder with the archive operation result will be placed. This folder will contain the following elements:
     * A file link named `bootstrap`
     * An executable file
-    * A **Zip** file ready to be upload to AWS
+    * A **Zip** file ready to be uploaded to AWS
 * `--verbose` A number that sets the command output detail level between the following values:
     * `0` (Silent)
     * `1` (Output)


### PR DESCRIPTION
changed 2 typos in readme.md (typo).

### Motivation:

There is two small typo's in readme.md.

### Modifications:

"contains" to "contain" and "upload" to "uploaded".

### Result:

No typo in that section.