### PR TITLE
Avoid warning when enabling strict concurrency check

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift
@@ -27,9 +27,9 @@ public protocol SimpleLambdaHandler {
     /// The lambda function's input. In most cases this should be `Codable`. If your event originates from an
     /// AWS service, have a look at [AWSLambdaEvents](https://github.com/swift-server/swift-aws-lambda-events),
     /// which provides a number of commonly used AWS Event implementations.
-    associatedtype Event
+    associatedtype Event: Sendable
     /// The lambda function's output. Can be `Void`.
-    associatedtype Output
+    associatedtype Output: Sendable
 
     init()
 
@@ -143,9 +143,9 @@ public protocol LambdaHandler {
     /// The lambda function's input. In most cases this should be `Codable`. If your event originates from an
     /// AWS service, have a look at [AWSLambdaEvents](https://github.com/swift-server/swift-aws-lambda-events),
     /// which provides a number of commonly used AWS Event implementations.
-    associatedtype Event
+    associatedtype Event: Sendable
     /// The lambda function's output. Can be `Void`.
-    associatedtype Output
+    associatedtype Output: Sendable
 
     /// The Lambda initialization method.
     /// Use this method to initialize resources that will be used in every request.
@@ -287,9 +287,9 @@ public protocol EventLoopLambdaHandler {
     /// The lambda functions input. In most cases this should be `Codable`. If your event originates from an
     /// AWS service, have a look at [AWSLambdaEvents](https://github.com/swift-server/swift-aws-lambda-events),
     /// which provides a number of commonly used AWS Event implementations.
-    associatedtype Event
+    associatedtype Event: Sendable
     /// The lambda functions output. Can be `Void`.
-    associatedtype Output
+    associatedtype Output: Sendable
 
     /// Create a Lambda handler for the runtime.
     ///


### PR DESCRIPTION
Avoid strict concurrency check warnings

### Motivation:

My Lambda function is an actor to protect instances variables from race condition.
```
@main
actor MyLambda: LambdaHandler { ... }
```
However, when I compile with
```
swift build -Xswiftc -strict-concurrency=complete
```
I receive this warning
```
warning: non-sendable type 'Self.Event' in parameter of the protocol requirement satisfied by actor-isolated instance method 'handle(_:context:)' cannot cross actor boundary
    func handle(_ event: APIGatewayV2Request, context: AWSLambdaRuntimeCore.LambdaContext) async throws -> APIGatewayV2Response {
```

What I understand from the error message is that `Event` must be `Sendable`. But `Event` is an associated type on LambdaHandler, see 
https://github.com/swift-server/swift-aws-lambda-runtime/blob/main/Sources/AWSLambdaRuntimeCore/LambdaHandler.swift#L146

In this case, it is an `APIGatewayV2Request` which correctly implements `Sendable` but it looks like the compiler can not detect that.

### Modifications:

I changed all occurences of `associatedtype Event` and `associatedtype Output` in `LambdaHandler.swift` to add `:Sendable`.
I did not check for Swift >=5.6 because I understand Swift 5.7 is the minimum version to compile the runtime.

### Result:

No compiler warnings when using `Xswiftc -strict-concurrency=complete`

