### PR TITLE
[plugin] Use LAMBDA_USE_LOCAL_DEPS env var in local builds with docker

### DIFF
--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -115,11 +115,24 @@ struct AWSLambdaPackager: CommandPlugin {
         for product in products {
             print("building \"\(product.name)\"")
             let buildCommand = "swift build -c \(buildConfiguration.rawValue) --product \(product.name) --static-swift-stdlib"
-            try self.execute(
-                executable: dockerToolPath,
-                arguments: ["run", "--rm", "-v", "\(packageDirectory.string):/workspace", "-w", "/workspace", baseImage, "bash", "-cl", buildCommand],
-                logLevel: verboseLogging ? .debug : .output
-            )
+            if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+                // when developing locally, we must have the full swift-aws-lambda-runtime project in the container
+                // because Examples' Package.swift have a dependency on ../..
+                // just like Package.swift's examples assume ../.., we assume we are two levels below the root project
+                let lastComponent = packageDirectory.lastComponent
+                let beforeLastComponent = packageDirectory.removingLastComponent().lastComponent
+                try self.execute(
+                    executable: dockerToolPath,
+                    arguments: ["run", "--rm", "--env", "LAMBDA_USE_LOCAL_DEPS=true", "-v", "\(packageDirectory.string)/../..:/workspace", "-w", "/workspace/\(beforeLastComponent)/\(lastComponent)", baseImage, "bash", "-cl", buildCommand],
+                    logLevel: verboseLogging ? .debug : .output
+                )
+            } else {
+                try self.execute(
+                    executable: dockerToolPath,
+                    arguments: ["run", "--rm", "-v", "\(packageDirectory.string):/workspace", "-w", "/workspace", baseImage, "bash", "-cl", buildCommand],
+                    logLevel: verboseLogging ? .debug : .output
+                )
+            }
             let productPath = buildOutputPath.appending(product.name)
             guard FileManager.default.fileExists(atPath: productPath.string) else {
                 Diagnostics.error("expected '\(product.name)' binary at \"\(productPath.string)\"")


### PR DESCRIPTION
Use the newly introduced `LAMBDA_USE_LOCAL_DEPS` environment variable inside Docker to allow to build Swift Lambda function using the local copy of the runtime 

### Motivation:

When developing and testing ideas on the Swift AWS Lambda Runtime, we often need to build code for deployment.
The local and CI build systems have been modified to allow to reference the local filesystem version of the library, instead of the remote one on Git. It uses the `LAMBDA_USE_LOCAL_DEPS` to make the difference. The examples' `Package.swift` have been updated by https://github.com/swift-server/swift-aws-lambda-runtime/pull/292 

### Modifications:

This PR, adds a check in the archiver plugin to mount `../..` in the docker container rather than `.` when building with local dependencies. This allows to refer to the local copy of the Swift AWS Lambda runtime library from within docker.

### Result:

```
LAMBDA_USE_LOCAL_DEPS=true swift package archive --disable-sandbox 

...

  Build complete! (5.28s)
-------------------------------------------------------------------------
archiving "MyLambda"
-------------------------------------------------------------------------
1 archive created
  * MyLambda at /Users/stormacq/<redacted>/swift-aws-lambda-runtime/Examples/Echo/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip
 
```
