### PR TITLE
Fix compile error on Windows

### DIFF
--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -205,7 +205,8 @@ struct AWSLambdaPackager: CommandPlugin {
             #if os(macOS) || os(Linux)
             let arguments = ["--junk-paths", "--symlinks", zipfilePath.string, relocatedArtifactPath.string, symbolicLinkPath.string]
             #else
-            throw Error.unsupportedPlatform("can't or don't know how to create a zip file on this platform")
+            let arguments = [String]()
+            throw Errors.unsupportedPlatform("can't or don't know how to create a zip file on this platform")
             #endif
 
             // run the zip tool


### PR DESCRIPTION
Fixes #327 

The package still doesn't fully compile but the next error is upstream in swift-nio:

```
PS C:\Users\sven_\Projects\swift-aws-lambda-runtime> swift build
C:\Users\sven_\Projects\swift-aws-lambda-runtime\Plugins\AWSLambdaPackager\Plugin.swift:213:13: warning: code after 'throw' will never be executed
            try self.execute(
            ^
C:\Users\sven_\Projects\swift-aws-lambda-runtime\.build\checkouts\swift-docc-plugin\Plugins\Swift-DocC Convert\Symbolic Links\SharedPackagePluginExtensions\PackageExtensions.swift:31:17: warning: switch covers known cases, but 'TargetDependency' may have additional unknown values
                switch dependency {
                ^
C:\Users\sven_\Projects\swift-aws-lambda-runtime\.build\checkouts\swift-docc-plugin\Plugins\Swift-DocC Convert\Symbolic Links\SharedPackagePluginExtensions\PackageExtensions.swift:31:17: note: handle unknown values using "@unknown default"
                switch dependency {
                ^
C:\Users\sven_\Projects\swift-aws-lambda-runtime\.build\checkouts\swift-docc-plugin\Plugins\Swift-DocC Preview\Symbolic Links\SharedPackagePluginExtensions\PackageExtensions.swift:31:17: warning: switch covers known cases, but 'TargetDependency' may have additional unknown values
                switch dependency {
                ^
C:\Users\sven_\Projects\swift-aws-lambda-runtime\.build\checkouts\swift-docc-plugin\Plugins\Swift-DocC Preview\Symbolic Links\SharedPackagePluginExtensions\PackageExtensions.swift:31:17: note: handle unknown values using "@unknown default"
                switch dependency {
                ^
Building for debugging...
C:\Users\sven_\Projects\swift-aws-lambda-runtime\.build\checkouts\swift-nio\Sources\NIOConcurrencyHelpers\lock.swift:225:74: error: value of type 'LockStorage<Void>' has no member 'mutex'
            if !SleepConditionVariableSRW(self.cond, self.mutex._storage.mutex,
                                                     ~~~~~~~~~~~~~~~~~~~ ^~~~~
error: fatalError
```