### PR TITLE
Allow injection of externally initialized ByteBufferAllocator

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -111,6 +111,7 @@ public enum Lambda {
                 let runtime = LambdaRuntime(
                     handlerProvider: handlerProvider,
                     eventLoop: eventLoop,
+                    allocator: ByteBufferAllocator(),
                     logger: logger,
                     configuration: configuration
                 )

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -24,10 +24,10 @@ internal final class LambdaRunner {
 
     private var isGettingNextInvocation = false
 
-    init(eventLoop: EventLoop, configuration: LambdaConfiguration) {
+    init(eventLoop: EventLoop, configuration: LambdaConfiguration, allocator: ByteBufferAllocator) {
         self.eventLoop = eventLoop
         self.runtimeClient = LambdaRuntimeClient(eventLoop: self.eventLoop, configuration: configuration.runtimeEngine)
-        self.allocator = ByteBufferAllocator()
+        self.allocator = allocator
     }
 
     /// Run the user provided initializer. This *must* only be called once.

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -276,7 +276,7 @@ class LambdaTest: XCTestCase {
         let task = Task.detached {
             print(configuration.description)
             logger.info("hello")
-            let runner = LambdaRunner(eventLoop: eventLoopGroup.next(), configuration: configuration)
+            let runner = LambdaRunner(eventLoop: eventLoopGroup.next(), configuration: configuration, allocator: ByteBufferAllocator())
 
             try await runner.run(
                 handler: CodableEventLoopLambdaHandler(

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -77,7 +77,7 @@ func runLambda(
     let logger = Logger(label: "TestLogger")
     let configuration = LambdaConfiguration(runtimeEngine: .init(requestTimeout: .milliseconds(100)))
     let terminator = LambdaTerminator()
-    let runner = LambdaRunner(eventLoop: eventLoopGroup.next(), configuration: configuration)
+    let runner = LambdaRunner(eventLoop: eventLoopGroup.next(), configuration: configuration, allocator: ByteBufferAllocator())
     let server = try MockLambdaServer(behavior: behavior).start().wait()
     defer { XCTAssertNoThrow(try server.stop().wait()) }
     try runner.initialize(handlerProvider: handlerProvider, logger: logger, terminator: terminator).flatMap { handler in


### PR DESCRIPTION
Allow the runtime's `ByteBufferAllocator` to be shared with other systems which are initialized __before__ the handler is instantiated.

### Motivation:

`LambdaRuntimeFactory.makeRuntime` is intended for scenarios requiring high customizability. It's reasonable to assume that these scenarios typically involve other subsystems, which might be initialized before `LambdaRuntimeHandler.init(context:)`.

The simplest example is a structured `swift-log` `LogHandler`, where logs are formatted and encoded into `ByteBuffers`. In this case, `LoggingSystem.bootstrap` needs to run before `LambdaRuntimeFactory.makeRuntime`, directly inside the `@main` entry point, and not inside the `LambdaRuntimeHandler.init(context:)` initializer.

### Modifications:

The private `allocator` of `LambdaRunner` is now injected through its initializer. All the `makeRuntime` methods take a `ByteBufferAllocator` parameter which defaults to a freshly initialized one if left unspecified. This prevents any breaking changes.

### Result:

```swift
static func main() async throws {
    let sharedAllocator = ByteBufferAllocator()
    LoggingSystem.bootstrap { label in
        CodableLogHandler(label: label, allocator: sharedAllocator)
    }
    let logger = Logger(label: "Lambda")
    
    // ...
    
    let runtime = LambdaRuntimeFactory.makeRuntime(
        handlerProvider: { context in
            eventLoop.makeSucceededFuture(
                SomeLambdaHandler(context: context)
            )
        },
        eventLoop: eventLoop,
        allocator: sharedAllocator,
        logger: logger
    )
    // ...
}
```