### PR TITLE
Add support for resources when packaging using the SwiftPM plugin

### DIFF
--- a/Examples/ResourcePackaging/Lambda.swift
+++ b/Examples/ResourcePackaging/Lambda.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSLambdaRuntime
+import Foundation
+
+// in this example we are reading from a bundled resource and responding with the contents
+
+@main
+struct MyLambda: SimpleLambdaHandler {
+    func handle(_ input: String, context: LambdaContext) async throws -> String {
+        let fileName = "hello.txt"
+        guard let resourceURL = Bundle.module.resourceURL else {
+            fatalError("unable to locate bundle resource url")
+        }
+        let fileURL = resourceURL.appendingPathComponent(fileName)
+        return try String(contentsOf: fileURL)
+    }
+}

--- a/Examples/ResourcePackaging/Lambda.swift
+++ b/Examples/ResourcePackaging/Lambda.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2024 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2021 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Examples/ResourcePackaging/Lambda.swift
+++ b/Examples/ResourcePackaging/Lambda.swift
@@ -20,11 +20,9 @@ import Foundation
 @main
 struct MyLambda: SimpleLambdaHandler {
     func handle(_ input: String, context: LambdaContext) async throws -> String {
-        let fileName = "hello.txt"
-        guard let resourceURL = Bundle.module.resourceURL else {
-            fatalError("unable to locate bundle resource url")
+        guard let fileURL = Bundle.module.url(forResource: "hello", withExtension: "txt") else {
+            fatalError("no file url")
         }
-        let fileURL = resourceURL.appendingPathComponent(fileName)
         return try String(contentsOf: fileURL)
     }
 }

--- a/Examples/ResourcePackaging/Package.swift
+++ b/Examples/ResourcePackaging/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.7
+
+import class Foundation.ProcessInfo // needed for CI to test the local version of the library
+import PackageDescription
+
+let package = Package(
+    name: "swift-aws-lambda-runtime-example",
+    platforms: [
+        .macOS(.v12),
+    ],
+    products: [
+        .executable(name: "MyLambda", targets: ["MyLambda"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyLambda",
+            dependencies: [
+                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
+            ],
+            path: ".",
+            resources: [
+                .process("hello.txt"),
+            ]
+        ),
+    ]
+)
+
+// for CI to test the local version of the library
+if ProcessInfo.processInfo.environment["LAMBDA_USE_LOCAL_DEPS"] != nil {
+    package.dependencies = [
+        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+    ]
+}

--- a/Examples/ResourcePackaging/hello.txt
+++ b/Examples/ResourcePackaging/hello.txt
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
This change updates the SwiftPM plugin to include the executable's resources in the archive.

### Motivation:

When deploying a Lambda function that generates HTML content I needed a way to package template HTML files along with the executable. Defining the resources in the `Package.swift` and then packaging them in the archive in a way so that Swift can access them using `Bundle.main.resourceURL` felt like the best way to accomplish this.

Example:

```
.executableTarget(
            name: "Website",
            dependencies: [
                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
            ],
            resources: [
                .process("template.stencil"),
            ]),
```

### Modifications:

Plugin code has been modified to generate a `Contents/Resources` directory inside the final archive which includes the resources defined in the executable's target from `Package.swift`.

### Result:

The zip archive includes the defined resources in `Package.swift`.
