### PR TITLE
[Draft] Detached tasks

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/DetachedTasks.swift
+++ b/Sources/AWSLambdaRuntimeCore/DetachedTasks.swift
@@ -1,0 +1,169 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import NIOConcurrencyHelpers
+import NIOCore
+import Logging
+
+/// A container that allows tasks to finish after a synchronous invocation
+/// has produced its response.
+public final class DetachedTasksContainer {
+
+    struct Context {
+        let eventLoop: EventLoop
+        let logger: Logger
+    }
+    
+    private var context: Context
+    private var storage: Storage
+
+    init(context: Context) {
+        self.storage = Storage()
+        self.context = context
+    }
+
+    /// Adds a detached task that runs on the given event loop.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the task.
+    ///   - task: The task to execute. It receives an `EventLoop` and returns an `EventLoopFuture<Void>`.
+    /// - Returns: A `RegistrationKey` for the registered task.
+    @discardableResult
+    public func detached(name: String, task: @escaping (EventLoop) -> EventLoopFuture<Void>) -> RegistrationKey {
+        let key = RegistrationKey()
+        let task = task(context.eventLoop).always { _ in
+            self.storage.remove(key)
+        }
+        self.storage.add(key: key, name: name, task: task)
+        return key
+    }
+    
+    /// Adds a detached async task.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the task.
+    ///   - task: The async task to execute.
+    /// - Returns: A `RegistrationKey` for the registered task.
+    @discardableResult
+    public func detached(name: String, task: @Sendable @escaping () async throws -> Void) -> RegistrationKey {
+        let key = RegistrationKey()
+        let promise = context.eventLoop.makePromise(of: Void.self)
+        promise.completeWithTask(task)
+        let task = promise.futureResult.always { result in
+            switch result {
+            case .success:
+                break
+            case .failure(let failure):
+                self.context.logger.warning(
+                    "Execution of detached task failed with error.",
+                    metadata: [
+                        "taskName": "\(name)",
+                        "error": "\(failure)"
+                    ]
+                )
+            }
+            self.storage.remove(key)
+        }
+        self.storage.add(key: key, name: name, task: task)
+        return key
+    }
+
+    /// Informs the runtime that the specified task should not be awaited anymore.
+    ///
+    /// - Warning: This method does not actually stop the execution of the
+    ///   detached task, it only prevents the runtime from waiting for it before
+    ///   `/next` is invoked.
+    ///
+    /// - Parameter key: The `RegistrationKey` of the task to cancel.
+    public func unsafeCancel(_ key: RegistrationKey) {
+        // To discuss:
+        // Canceling the execution doesn't seem to be an easy
+        // task https://github.com/apple/swift-nio/issues/2087
+        //
+        // While removing the handler will allow the runtime
+        // to invoke `/next` without actually awaiting for the
+        // task to complete, it does not actually cancel
+        // the execution of the dispatched task.
+        // Since this is a bit counter-intuitive, we might not
+        // want this method to exist at all.
+        self.storage.remove(key)
+    }
+
+    /// Awaits all registered tasks to complete.
+    ///
+    /// - Returns: An `EventLoopFuture<Void>` that completes when all tasks have finished.
+    internal func awaitAll() -> EventLoopFuture<Void> {
+        let tasks = storage.tasks
+        if tasks.isEmpty {
+            return context.eventLoop.makeSucceededVoidFuture()
+        } else {
+            return EventLoopFuture.andAllComplete(tasks.map(\.value.task), on: context.eventLoop).flatMap {
+                self.awaitAll()
+            }
+        }
+    }
+}
+
+extension DetachedTasksContainer {
+    /// Lambda detached task registration key.
+    public struct RegistrationKey: Hashable, CustomStringConvertible {
+        var value: String
+
+        init() {
+            // UUID basically
+            self.value = UUID().uuidString
+        }
+
+        public var description: String {
+            self.value
+        }
+    }
+}
+
+extension DetachedTasksContainer {
+    fileprivate final class Storage {
+        private let lock: NIOLock
+        
+        private var map: [RegistrationKey: (name: String, task: EventLoopFuture<Void>)]
+
+        init() {
+            self.lock = .init()
+            self.map = [:]
+        }
+
+        func add(key: RegistrationKey, name: String, task: EventLoopFuture<Void>) {
+            self.lock.withLock {
+                self.map[key] = (name: name, task: task)
+            }
+        }
+
+        func remove(_ key: RegistrationKey) {
+            self.lock.withLock {
+                self.map[key] = nil
+            }
+        }
+
+        var tasks: [RegistrationKey: (name: String, task: EventLoopFuture<Void>)] {
+            self.lock.withLock {
+                self.map
+            }
+        }
+    }
+}
+
+// Ideally this would not be @unchecked Sendable, but Sendable checks do not understand locks
+// We can transition this to an actor once we drop support for older Swift versions
+extension DetachedTasksContainer: @unchecked Sendable {}
+extension DetachedTasksContainer.Storage: @unchecked Sendable {}
+extension DetachedTasksContainer.RegistrationKey: Sendable {}

--- a/Sources/AWSLambdaRuntimeCore/DetachedTasks.swift
+++ b/Sources/AWSLambdaRuntimeCore/DetachedTasks.swift
@@ -79,27 +79,6 @@ public final class DetachedTasksContainer {
         return key
     }
 
-    /// Informs the runtime that the specified task should not be awaited anymore.
-    ///
-    /// - Warning: This method does not actually stop the execution of the
-    ///   detached task, it only prevents the runtime from waiting for it before
-    ///   `/next` is invoked.
-    ///
-    /// - Parameter key: The `RegistrationKey` of the task to cancel.
-    public func unsafeCancel(_ key: RegistrationKey) {
-        // To discuss:
-        // Canceling the execution doesn't seem to be an easy
-        // task https://github.com/apple/swift-nio/issues/2087
-        //
-        // While removing the handler will allow the runtime
-        // to invoke `/next` without actually awaiting for the
-        // task to complete, it does not actually cancel
-        // the execution of the dispatched task.
-        // Since this is a bit counter-intuitive, we might not
-        // want this method to exist at all.
-        self.storage.remove(key)
-    }
-
     /// Awaits all registered tasks to complete.
     ///
     /// - Returns: An `EventLoopFuture<Void>` that completes when all tasks have finished.

--- a/Sources/AWSLambdaRuntimeCore/DetachedTasks.swift
+++ b/Sources/AWSLambdaRuntimeCore/DetachedTasks.swift
@@ -33,22 +33,6 @@ public final class DetachedTasksContainer {
         self.context = context
     }
 
-    /// Adds a detached task that runs on the given event loop.
-    ///
-    /// - Parameters:
-    ///   - name: The name of the task.
-    ///   - task: The task to execute. It receives an `EventLoop` and returns an `EventLoopFuture<Void>`.
-    /// - Returns: A `RegistrationKey` for the registered task.
-    @discardableResult
-    public func detached(name: String, task: @escaping (EventLoop) -> EventLoopFuture<Void>) -> RegistrationKey {
-        let key = RegistrationKey()
-        let task = task(context.eventLoop).always { _ in
-            self.storage.remove(key)
-        }
-        self.storage.add(key: key, name: name, task: task)
-        return key
-    }
-    
     /// Adds a detached async task.
     ///
     /// - Parameters:

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -222,13 +222,7 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             deadline: .now() + timeout,
             logger: logger,
             eventLoop: eventLoop,
-            allocator: ByteBufferAllocator(),
-            tasks: DetachedTasksContainer(
-                context: DetachedTasksContainer.Context(
-                    eventLoop: eventLoop,
-                    logger: logger
-                )
-            )
+            allocator: ByteBufferAllocator()
         )
     }
 }

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -81,6 +81,7 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         let logger: Logger
         let eventLoop: EventLoop
         let allocator: ByteBufferAllocator
+        let tasks: DetachedTasksContainer
 
         init(
             requestID: String,
@@ -91,7 +92,8 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             clientContext: String?,
             logger: Logger,
             eventLoop: EventLoop,
-            allocator: ByteBufferAllocator
+            allocator: ByteBufferAllocator,
+            tasks: DetachedTasksContainer
         ) {
             self.requestID = requestID
             self.traceID = traceID
@@ -102,6 +104,7 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             self.logger = logger
             self.eventLoop = eventLoop
             self.allocator = allocator
+            self.tasks = tasks
         }
     }
 
@@ -158,6 +161,10 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
     public var allocator: ByteBufferAllocator {
         self.storage.allocator
     }
+    
+    public var tasks: DetachedTasksContainer {
+        self.storage.tasks
+    }
 
     init(requestID: String,
          traceID: String,
@@ -177,7 +184,13 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             clientContext: clientContext,
             logger: logger,
             eventLoop: eventLoop,
-            allocator: allocator
+            allocator: allocator,
+            tasks: DetachedTasksContainer(
+                context: DetachedTasksContainer.Context(
+                    eventLoop: eventLoop,
+                    logger: logger
+                )
+            )
         )
     }
 
@@ -209,7 +222,13 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             deadline: .now() + timeout,
             logger: logger,
             eventLoop: eventLoop,
-            allocator: ByteBufferAllocator()
+            allocator: ByteBufferAllocator(),
+            tasks: DetachedTasksContainer(
+                context: DetachedTasksContainer.Context(
+                    eventLoop: eventLoop,
+                    logger: logger
+                )
+            )
         )
     }
 }

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -202,6 +202,13 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         self.storage.tasks
     }
     
+    
+    /// Registers a background task that continues running after the synchronous invocation has completed.
+    /// This is useful for tasks like flushing metrics or performing clean-up operations without delaying the response.
+    ///
+    /// - Parameter body: An asynchronous closure that performs the background task.
+    /// - Warning: You will be billed for the milliseconds of Lambda execution time until the very last
+    ///   background task is finished.
     public func detachedBackgroundTask(_ body: @escaping @Sendable () async -> ()) {
         Task {
             await self.tasks.detached(task: body)

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -202,7 +202,7 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         self.storage.tasks
     }
     
-    func detachedBackgroundTask(_ body: @escaping @Sendable () async -> ()) {
+    public func detachedBackgroundTask(_ body: @escaping @Sendable () async -> ()) {
         Task {
             await self.tasks.detached(task: body)
         }

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -161,10 +161,6 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
     public var allocator: ByteBufferAllocator {
         self.storage.allocator
     }
-    
-    public var tasks: DetachedTasksContainer {
-        self.storage.tasks
-    }
 
     init(requestID: String,
          traceID: String,
@@ -200,6 +196,14 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
 
         let remaining = deadline - now
         return .milliseconds(remaining)
+    }
+    
+    var tasks: DetachedTasksContainer {
+        self.storage.tasks
+    }
+    
+    func detachedBackgroundTask(_ body: @escaping @Sendable () async -> ()) {
+        self.tasks.detached(task: body)
     }
 
     public var debugDescription: String {

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -203,7 +203,9 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
     }
     
     func detachedBackgroundTask(_ body: @escaping @Sendable () async -> ()) {
-        self.tasks.detached(task: body)
+        Task {
+            await self.tasks.detached(task: body)
+        }
     }
 
     public var debugDescription: String {

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -95,13 +95,19 @@ internal final class LambdaRunner {
                     if case .failure(let error) = result {
                         logger.warning("lambda handler returned an error: \(error)")
                     }
-                    return (invocation, result)
+                    return (invocation, result, context)
                 }
-        }.flatMap { invocation, result in
+        }.flatMap { invocation, result, context in
             // 3. report results to runtime engine
             self.runtimeClient.reportResults(logger: logger, invocation: invocation, result: result).peekError { error in
                 logger.error("could not report results to lambda runtime engine: \(error)")
-            }
+                // To discuss:
+                // Do we want to await the tasks in this case?
+                return context.tasks.awaitAll()
+            }.map { _ in context }
+        }
+        .flatMap { context in
+            context.tasks.awaitAll()
         }
     }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -110,7 +110,7 @@ internal final class LambdaRunner {
                 return promise.futureResult
             }.map { _ in context }
         }
-        .flatMap { context in
+        .flatMap { (context: LambdaContext) -> EventLoopFuture<Void> in
             let promise = context.eventLoop.makePromise(of: Void.self)
             promise.completeWithTask {
                 try await context.tasks.awaitAll().get()

--- a/Tests/AWSLambdaRuntimeCoreTests/DetachedTasksTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/DetachedTasksTests.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import AWSLambdaRuntimeCore
+import NIO
+import XCTest
+import Logging
+
+class DetachedTasksTest: XCTestCase {
+    
+    actor Expectation {
+        var isFulfilled = false
+        func fulfill() {
+            isFulfilled = true
+        }
+    }
+    
+    func testAwaitTasks() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        
+        let context = DetachedTasksContainer.Context(
+            eventLoop: eventLoopGroup.next(),
+            logger: Logger(label: "test")
+        )
+        let expectation = Expectation()
+        
+        let container = DetachedTasksContainer(context: context)
+        await container.detached {
+            try! await Task.sleep(for: .milliseconds(200))
+            await expectation.fulfill()
+        }
+        
+        try await container.awaitAll().get()
+        let isFulfilled = await expectation.isFulfilled
+        XCTAssert(isFulfilled)
+    }
+    
+    func testAwaitChildrenTasks() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        
+        let context = DetachedTasksContainer.Context(
+            eventLoop: eventLoopGroup.next(),
+            logger: Logger(label: "test")
+        )
+        let expectation1 = Expectation()
+        let expectation2 = Expectation()
+        
+        let container = DetachedTasksContainer(context: context)
+        await container.detached {
+            await container.detached {
+                try! await Task.sleep(for: .milliseconds(300))
+                await expectation1.fulfill()
+            }
+            try! await Task.sleep(for: .milliseconds(200))
+            await container.detached {
+                try! await Task.sleep(for: .milliseconds(100))
+                await expectation2.fulfill()
+            }
+        }
+        
+        try await container.awaitAll().get()
+        let isFulfilled1 = await expectation1.isFulfilled
+        let isFulfilled2 = await expectation2.isFulfilled
+        XCTAssert(isFulfilled1)
+        XCTAssert(isFulfilled2)
+    }
+}


### PR DESCRIPTION
Introduces a system that allows to keep the execution environment running after submitting the response for a synchronous invocation.

### Note:

This is a draft PR, only meant to gather feedbacks. This code requires some polishing and testing.
The lines commented with `// To discuss:` require careful consideration.

### Motivation:

It is common for a Lambda function to depend on several other serverless services (SQS, APIGW WebSockets, SNS, EventBridge, X-Ray just to name a few). In many occasions, such services might perform non-critical work like sending a push notification to the user, store metrics or flush a set of spans. In these scenarios, the occurrence of a non-recoverable error usually doesn't mean that the whole invocation should fail and result in a sad 500. At the same time, awaiting for such tasks to finish gives no benefits and drastically increases the latency for the API consumers.

This PR implements a hook in the runtime which allows the developer to dispatch code that can continue its execution **after** the invocation of `/response` and before having the environment being frozen by `/next`. This is a common practice described [here](https://aws.amazon.com/blogs/compute/running-code-after-returning-a-response-from-an-aws-lambda-function/).

### Modifications:

A new class called `DetachedTaskContainer` has been added, which follows the design of `LambdaTerminator` as close as possible. A `LambdaContext` now owns an instance of `DetachedTaskContainer`, which can be used by the handler to dispatch asynchrouns non-critical work that can finish **after** the invocation of `/response` and before `/next`.

### Result:

It is now possible to return the result of a synchronous invocation (like API Gateway integration, CloudFront origin, Lambda function URL, Cognito Custom Auth, etc), as soon as it is ready, reducing the overall API latency.

```swift
func handle(_ buffer: ByteBuffer, context: LambdaContext) -> EventLoopFuture<ByteBuffer?> {
    // EventLoop API
    context.tasks.detached(name: "Example 1") { eventLoop in
        return performSomeWork(on: eventLoop).map { result in
            context.logger.info("\(result) has been provided at \(Date())")
        }
    }
    // Async API
    context.tasks.detached(name: "Example 2") {
        try await Task.sleep(for: .seconds(3))
        context.logger.info("Hello World!")
    }
    let response = encodedAPIGatewayResponse()
    return context.eventLoop.makeSucceededFuture(response)
}
```