### PR TITLE
Don't use hardcoded port for MockServer

### DIFF
--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -34,7 +34,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -60,7 +63,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -89,7 +95,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -116,7 +125,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldFailWithError: TestError("kaboom"))
     }
@@ -135,7 +147,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -152,7 +167,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
 
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
@@ -172,7 +190,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -197,7 +218,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -220,7 +244,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -243,7 +270,10 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let configuration = LambdaConfiguration(
+            lifecycle: .init(maxTimes: maxTimes),
+            runtimeEngine: .init(address: "127.0.0.1:\(port)")
+        )
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaHandlerTest.swift
@@ -22,7 +22,9 @@ class LambdaHandlerTest: XCTestCase {
 
     func testBootstrapSimpleNoInit() {
         let server = MockLambdaServer(behavior: Behavior())
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: SimpleLambdaHandler {
@@ -32,14 +34,16 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
 
     func testBootstrapSimpleInit() {
         let server = MockLambdaServer(behavior: Behavior())
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: SimpleLambdaHandler {
@@ -56,7 +60,7 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -65,7 +69,9 @@ class LambdaHandlerTest: XCTestCase {
 
     func testBootstrapSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: LambdaHandler {
@@ -83,14 +89,16 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
 
     func testBootstrapFailure() {
         let server = MockLambdaServer(behavior: FailedBootstrapBehavior())
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct TestBootstrapHandler: LambdaHandler {
@@ -108,14 +116,16 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 10...20)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: TestBootstrapHandler.self)
         assertLambdaRuntimeResult(result, shouldFailWithError: TestError("kaboom"))
     }
 
     func testHandlerSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: SimpleLambdaHandler {
@@ -125,14 +135,16 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
 
     func testVoidHandlerSuccess() {
         let server = MockLambdaServer(behavior: Behavior(result: .success(nil)))
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: SimpleLambdaHandler {
@@ -140,7 +152,7 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
 
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
@@ -148,7 +160,9 @@ class LambdaHandlerTest: XCTestCase {
 
     func testHandlerFailure() {
         let server = MockLambdaServer(behavior: Behavior(result: .failure(TestError("boom"))))
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: SimpleLambdaHandler {
@@ -158,7 +172,7 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
@@ -167,7 +181,9 @@ class LambdaHandlerTest: XCTestCase {
 
     func testEventLoopSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
@@ -181,14 +197,16 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
 
     func testVoidEventLoopSuccess() {
         let server = MockLambdaServer(behavior: Behavior(result: .success(nil)))
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
@@ -202,14 +220,16 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
 
     func testEventLoopFailure() {
         let server = MockLambdaServer(behavior: Behavior(result: .failure(TestError("boom"))))
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
@@ -223,14 +243,16 @@ class LambdaHandlerTest: XCTestCase {
         }
 
         let maxTimes = Int.random(in: 1...10)
-        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes))
+        let configuration = LambdaConfiguration(lifecycle: .init(maxTimes: maxTimes), runtimeEngine: .init(address: "127.0.0.1:\(port)"))
         let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldHaveRun: maxTimes)
     }
 
     func testEventLoopBootstrapFailure() {
         let server = MockLambdaServer(behavior: FailedBootstrapBehavior())
-        XCTAssertNoThrow(try server.start().wait())
+        var port: Int?
+        XCTAssertNoThrow(port = try server.start().wait())
+        guard let port else { return XCTFail("Expected the server to have started") }
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
@@ -244,7 +266,8 @@ class LambdaHandlerTest: XCTestCase {
             }
         }
 
-        let result = Lambda.run(configuration: .init(), handlerType: Handler.self)
+        let configuration = LambdaConfiguration(runtimeEngine: .init(address: "127.0.0.1:\(port)"))
+        let result = Lambda.run(configuration: configuration, handlerType: Handler.self)
         assertLambdaRuntimeResult(result, shouldFailWithError: TestError("kaboom"))
     }
 }

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -279,7 +279,9 @@ class LambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         let logger = Logger(label: "TestLogger")
-        let configuration = LambdaConfiguration(runtimeEngine: .init(address: "127.0.0.1:\(port)", requestTimeout: .milliseconds(100)))
+        let configuration = LambdaConfiguration(
+            runtimeEngine: .init(address: "127.0.0.1:\(port)", requestTimeout: .milliseconds(100))
+        )
 
         let handler1 = Handler()
         let task = Task.detached {

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -84,7 +84,9 @@ func runLambda(
     let logger = Logger(label: "TestLogger")
     let server = MockLambdaServer(behavior: behavior, port: 0)
     let port = try server.start().wait()
-    let configuration = LambdaConfiguration(runtimeEngine: .init(address: "127.0.0.1:\(port)", requestTimeout: .milliseconds(100)))
+    let configuration = LambdaConfiguration(
+        runtimeEngine: .init(address: "127.0.0.1:\(port)", requestTimeout: .milliseconds(100))
+    )
     let terminator = LambdaTerminator()
     let runner = LambdaRunner(eventLoop: eventLoopGroup.next(), configuration: configuration)
     defer { XCTAssertNoThrow(try server.stop().wait()) }

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -82,10 +82,11 @@ func runLambda(
     let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
     let logger = Logger(label: "TestLogger")
-    let configuration = LambdaConfiguration(runtimeEngine: .init(requestTimeout: .milliseconds(100)))
+    let server = MockLambdaServer(behavior: behavior, port: 0)
+    let port = try server.start().wait()
+    let configuration = LambdaConfiguration(runtimeEngine: .init(address: "127.0.0.1:\(port)", requestTimeout: .milliseconds(100)))
     let terminator = LambdaTerminator()
     let runner = LambdaRunner(eventLoop: eventLoopGroup.next(), configuration: configuration)
-    let server = try MockLambdaServer(behavior: behavior).start().wait()
     defer { XCTAssertNoThrow(try server.stop().wait()) }
     try runner.initialize(handlerProvider: handlerProvider, logger: logger, terminator: terminator).flatMap { handler in
         runner.run(handler: handler, logger: logger)


### PR DESCRIPTION
For the MockServer we should not use a hardcoded port.

### Motivation:

- We want to be able to run unit tests in parallel

### Modifications:

- The MockServer can now pick its own port and report the port it picked back to the user.

### Result:

Tests can run in parallel.