### PR TITLE
Depend on NIOCore and NIOPosix instead of NIO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,8 @@ let package = Package(
             name: "AWSLambdaTesting",
             dependencies: [
                 .byName(name: "AWSLambdaRuntime"),
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ]
         ),
         .testTarget(
@@ -97,7 +98,8 @@ let package = Package(
             name: "MockServer",
             dependencies: [
                 .product(name: "NIOHTTP1", package: "swift-nio"),
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),


### PR DESCRIPTION
### Motivation:

We can depend on `NIOCore` and `NIOPosix` instead of `NIO` to reduce package size.

### Modifications:

- Removed `NIO` and instead added `NIOCore` and `NIOPosix` in `Package.swift`.

### Result:

Reduced package size.