### PR TITLE
Allow docker access in archiver plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -57,7 +57,11 @@ let package = Package(
                         "Archive the Lambda binary and prepare it for uploading to AWS. Requires docker on macOS or non Amazonlinux 2 distributions."
                 ),
                 permissions: [
-                    .allowNetworkConnections(scope: .docker, reason: "The archiver plugin needs docker to build the executable that can be run in AWS Lambda.")
+                    .allowNetworkConnections(
+                        scope: .docker,
+                        reason:
+                            "The archiver plugin needs docker to build the executable that can be run in AWS Lambda."
+                    )
                 ]
             )
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,10 @@ let package = Package(
                     verb: "archive",
                     description:
                         "Archive the Lambda binary and prepare it for uploading to AWS. Requires docker on macOS or non Amazonlinux 2 distributions."
-                )
+                ),
+                permissions: [
+                    .allowNetworkConnections(scope: .docker, reason: "The archiver plugin needs docker to build the executable that can be run in AWS Lambda.")
+                ]
             )
         ),
         .testTarget(

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import PackagePlugin
 import Foundation
+import PackagePlugin
 
 @main
 @available(macOS 15.0, *)
@@ -112,7 +112,9 @@ struct AWSLambdaPackager: CommandPlugin {
         guard let buildPathOutput = dockerBuildOutputPath.split(separator: "\n").last else {
             throw Errors.failedParsingDockerOutput(dockerBuildOutputPath)
         }
-        let buildOutputPath = URL(string: buildPathOutput.replacingOccurrences(of: "/workspace/", with: packageDirectory.description))!            
+        let buildOutputPath = URL(
+            string: buildPathOutput.replacingOccurrences(of: "/workspace/", with: packageDirectory.description)
+        )!
 
         // build the products
         var builtProducts = [LambdaProduct: URL]()
@@ -126,7 +128,7 @@ struct AWSLambdaPackager: CommandPlugin {
                 // just like Package.swift's examples assume ../.., we assume we are two levels below the root project
                 let slice = packageDirectory.pathComponents.suffix(2)
                 let beforeLastComponent = packageDirectory.pathComponents[slice.startIndex]
-                let lastComponent = packageDirectory.pathComponents[slice.endIndex-1]
+                let lastComponent = packageDirectory.pathComponents[slice.endIndex - 1]
                 try Utils.execute(
                     executable: dockerToolPath,
                     arguments: [
@@ -302,7 +304,7 @@ private struct Configuration: CustomStringConvertible {
             var isDirectory: Bool = false
             #else
             var isDirectory: ObjCBool = false
-            #endif 
+            #endif
             guard FileManager.default.fileExists(atPath: outputPath, isDirectory: &isDirectory)
             else {
                 throw Errors.invalidArgument("invalid output directory '\(outputPath)'")
@@ -447,7 +449,9 @@ private struct LambdaProduct: Hashable {
 extension PackageManager.BuildResult {
     // find the executable produced by the build
     func executableArtifact(for product: Product) -> PackageManager.BuildResult.BuiltArtifact? {
-        let executables = self.builtArtifacts.filter { $0.kind == .executable && $0.url.lastPathComponent == product.name }
+        let executables = self.builtArtifacts.filter {
+            $0.kind == .executable && $0.url.lastPathComponent == product.name
+        }
         guard !executables.isEmpty else {
             return nil
         }

--- a/Plugins/AWSLambdaPackager/PluginUtils.swift
+++ b/Plugins/AWSLambdaPackager/PluginUtils.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+import Foundation
 import PackagePlugin
 import Synchronization
-import Foundation
 
 @available(macOS 15.0, *)
 struct Utils {

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -14,15 +14,15 @@
 
 import Foundation
 import Logging
-import NIOCore
 import NIOConcurrencyHelpers
+import NIOCore
 
 // We need `@unchecked` Sendable here, as `NIOLockedValueBox` does not understand `sending` today.
 // We don't want to use `NIOLockedValueBox` here anyway. We would love to use Mutex here, but this
 // sadly crashes the compiler today.
 public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: StreamingLambdaHandler {
     // TODO: We want to change this to Mutex as soon as this doesn't crash the Swift compiler on Linux anymore
-    let handlerMutex: NIOLockedValueBox<Optional<Handler>>
+    let handlerMutex: NIOLockedValueBox<Handler?>
     let logger: Logger
     let eventLoop: EventLoop
 


### PR DESCRIPTION
Allow plugin to use unix domain socket to interact with docker. This should eliminate the use of `--disable-sandbox` for "normal" docker installs (unchanged docker context).