### PR TITLE
add docker fine grained permission to the plugin

### DIFF
--- a/Examples/APIGateway/README.md
+++ b/Examples/APIGateway/README.md
@@ -22,7 +22,7 @@ To build the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --disable-sandbox
+swift package archive --allow-network-access docker
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Examples/HelloWorld/README.md
+++ b/Examples/HelloWorld/README.md
@@ -18,7 +18,7 @@ To build & archive the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --disable-sandbox
+swift package archive --allow-network-access docker
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,13 @@ let package = Package(
                     verb: "archive",
                     description:
                         "Archive the Lambda binary and prepare it for uploading to AWS. Requires docker on macOS or non Amazonlinux 2 distributions."
-                )
+                ),
+permissions: [
+                    .allowNetworkConnections(
+                        scope: .docker,
+                        reason: "This plugin uses Docker to create the AWS Lambda ZIP package."
+                    )
+                ]                
             )
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -56,12 +56,12 @@ let package = Package(
                     description:
                         "Archive the Lambda binary and prepare it for uploading to AWS. Requires docker on macOS or non Amazonlinux 2 distributions."
                 ),
-permissions: [
+                permissions: [
                     .allowNetworkConnections(
                         scope: .docker,
                         reason: "This plugin uses Docker to create the AWS Lambda ZIP package."
                     )
-                ]                
+                ]
             )
         ),
         .testTarget(

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -287,7 +287,7 @@ struct AWSLambdaPackager: CommandPlugin {
 
             REQUIREMENTS: To use this plugin, you must have docker installed and started.
 
-            USAGE: swift package --disable-sandbox archive [--help] [--verbose]
+            USAGE: swift package --allow-network-access docker archive [--help] [--verbose]
                                                        [--output-directory <path>]
                                                        [--products <list of products>]
                                                        [--configuration debug | release]

--- a/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/04-01-02-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/04-01-02-plugin-archive.sh
@@ -1,2 +1,2 @@
-swift package --disable-sandbox plugin archive
+swift package --allow-network-access docker plugin archive
 

--- a/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/04-01-03-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/04-01-03-plugin-archive.sh
@@ -1,4 +1,4 @@
-swift package --disable-sandbox plugin archive
+swift package --allow-network-access docker archive
 
 -------------------------------------------------------------------------
 building "squarenumberlambda" in docker

--- a/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/04-01-04-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/04-01-04-plugin-archive.sh
@@ -1,4 +1,4 @@
-swift package --disable-sandbox plugin archive
+swift package --allow-network-access docker archive
 
 -------------------------------------------------------------------------
 building "squarenumberlambda" in docker

--- a/Sources/AWSLambdaRuntimeCore/Documentation.docc/quick-setup.md
+++ b/Sources/AWSLambdaRuntimeCore/Documentation.docc/quick-setup.md
@@ -106,7 +106,7 @@ AWS Lambda runtime runs on Amazon Linux. You must compile your code for Amazon L
 > Be sure to have [Docker](https://docs.docker.com/desktop/install/mac-install/) installed for this step.
 
 ```sh
-swift package --disable-sandbox plugin archive
+swift package --allow-network-access docker archive
 
 -------------------------------------------------------------------------
 building "squarenumberlambda" in docker

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ try await runtime.run()
 
 ```bash
 swift build
-swift package archive --disable-sandbox
+swift package archive --allow-network-access docker
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 


### PR DESCRIPTION
removes the need to `--disable-sandbox` and update docs and examples