### PR TITLE
Remove swift-testing package dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,7 +92,7 @@ let package = Package(
         .testTarget(
             name: "AWSLambdaTestingTests",
             dependencies: [
-                .byName(name: "AWSLambdaTesting"),
+                .byName(name: "AWSLambdaTesting")
             ]
         ),
         // for perf testing

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,8 @@ let package = Package(
         .library(name: "AWSLambdaTesting", targets: ["AWSLambdaTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.72.0")),
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.4")),
-        .package(url: "https://github.com/apple/swift-testing.git", branch: "swift-DEVELOPMENT-SNAPSHOT-2024-08-29-a"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.72.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     ],
     targets: [
         .target(
@@ -70,7 +69,6 @@ let package = Package(
                 .byName(name: "AWSLambdaRuntimeCore"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
-                .product(name: "Testing", package: "swift-testing"),
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
@@ -79,7 +77,6 @@ let package = Package(
             dependencies: [
                 .byName(name: "AWSLambdaRuntimeCore"),
                 .byName(name: "AWSLambdaRuntime"),
-                .product(name: "Testing", package: "swift-testing"),
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
@@ -96,7 +93,6 @@ let package = Package(
             name: "AWSLambdaTestingTests",
             dependencies: [
                 .byName(name: "AWSLambdaTesting"),
-                .product(name: "Testing", package: "swift-testing"),
             ]
         ),
         // for perf testing


### PR DESCRIPTION
We should land #392 first and then rebase on top of it.