### PR TITLE
import foundationEssentials for the archiver plugin

### DIFF
--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -12,8 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import PackagePlugin
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import class Foundation.FileManager
+import class Foundation.ProcessInfo
+import struct Foundation.ObjCBool
+#endif
 
 @main
 @available(macOS 15.0, *)

--- a/Plugins/AWSLambdaPackager/PluginUtils.swift
+++ b/Plugins/AWSLambdaPackager/PluginUtils.swift
@@ -13,9 +13,18 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import Foundation
 import PackagePlugin
 import Synchronization
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import struct Foundation.CharacterSet
+import struct Foundation.Data
+import class Foundation.Pipe
+import class Foundation.Process
+#endif
 
 @available(macOS 15.0, *)
 struct Utils {


### PR DESCRIPTION
working towards the goal of removing import of Foundation
https://github.com/swift-server/swift-aws-lambda-runtime/issues/402