### PR TITLE
Do not run python linter during CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       license_header_check_project_name: "SwiftAWSLambdaRuntime"
       shell_check_enabled: false
+      python_lint_check_enabled: false
       api_breakage_check_container_image: "swift:6.0-noble"
       docs_check_container_image: "swift:6.0-noble"
       format_check_container_image: "swiftlang/swift:nightly-6.0-jammy"


### PR DESCRIPTION
Recently added python linter in swiftlang/github-workflows causes the CI to break.
We don't use python in this project, I'm disabling it