### PR TITLE
[CI] drop Swift 5.8

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_8_enabled: false
       linux_5_9_enabled: false
       linux_5_10_enabled: false
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"


### PR DESCRIPTION
Align to the new version of the CI script is Swift NIO project https://github.com/apple/swift-nio/commit/c16420c4a7e026174e4eb373953a8eae41a7a4a8
