### PR TITLE
[CI] add testing on musl

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Install SDK
         run: swift sdk install https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
       - name: Build
-        run: swift build --swift-sdk x86_64-swift-linux-musl ${PACKAGE_PATH} ${EXTRA_FLAGS} ${EXTRA_MUSL_FLAGS} ${WARNINGS_AS_ERRORS}
+        run: swift build --swift-sdk x86_64-swift-linux-musl

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,3 +43,17 @@ jobs:
   swift-6-language-mode:
     name: Swift 6 Language Mode
     uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main
+
+  # until there is a support for musl in swiftlang/github-workflows
+  # https://github.com/swiftlang/github-workflows/issues/34
+  musl:
+      runs-on: ubuntu-latest
+      container: swift:6.0-noble
+      timeout-minutes: 30
+      steps:
+        - name: Check out code
+          uses: actions/checkout@v4
+        - name: Install SDK
+          run: swift sdk install https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
+        - name: Build
+          run: swift build --swift-sdk x86_64-swift-linux-musl ${PACKAGE_PATH} ${EXTRA_FLAGS} ${EXTRA_MUSL_FLAGS} ${WARNINGS_AS_ERRORS}    

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,13 +46,13 @@ jobs:
   # until there is a support for musl in swiftlang/github-workflows
   # https://github.com/swiftlang/github-workflows/issues/34
   musl:
-      runs-on: ubuntu-latest
-      container: swift:6.0-noble
-      timeout-minutes: 30
-      steps:
-        - name: Check out code
-          uses: actions/checkout@v4
-        - name: Install SDK
-          run: swift sdk install https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
-        - name: Build
-          run: swift build --swift-sdk x86_64-swift-linux-musl ${PACKAGE_PATH} ${EXTRA_FLAGS} ${EXTRA_MUSL_FLAGS} ${WARNINGS_AS_ERRORS}    
+    runs-on: ubuntu-latest
+    container: swift:6.0-noble
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install SDK
+        run: swift sdk install https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
+      - name: Build
+        run: swift build --swift-sdk x86_64-swift-linux-musl ${PACKAGE_PATH} ${EXTRA_FLAGS} ${EXTRA_MUSL_FLAGS} ${WARNINGS_AS_ERRORS}


### PR DESCRIPTION
Musl allows to create self-contained binary that do not required any linux library 

This is a promising path forward for the runtime as it would allow to reduce the binary dependencies on the OS managed by Lambda (think about a migration from Amazon Linux 2 to Amazon Linux 2023) 

While, there will probably have an impact of startup times due to larger binary, musl should be a packaging option for developers that want to use it.