### PR TITLE
Set the log level to LOG_LEVEL env variable

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,12 +47,12 @@ jobs:
   # https://github.com/swiftlang/github-workflows/issues/34
   musl:
     runs-on: ubuntu-latest
-    container: swift:6.0-noble
+    container: swift:6.0.2-noble
     timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Install SDK
-        run: swift sdk install https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
+        run: swift sdk install https://download.swift.org/swift-6.0.2-release/static-sdk/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum aa5515476a403797223fc2aad4ca0c3bf83995d5427fb297cab1d93c68cee075
       - name: Build
         run: swift build --swift-sdk x86_64-swift-linux-musl

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -23,7 +23,7 @@ import NIOCore
 public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: StreamingLambdaHandler {
     // TODO: We want to change this to Mutex as soon as this doesn't crash the Swift compiler on Linux anymore
     let handlerMutex: NIOLockedValueBox<Handler?>
-    var logger: Logger
+    let logger: Logger
     let eventLoop: EventLoop
 
     public init(
@@ -33,6 +33,12 @@ public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: St
     ) {
         self.handlerMutex = NIOLockedValueBox(handler)
         self.eventLoop = eventLoop
+
+        // by setting the log level here, we understand it can not be changed dynamically at runtime
+        // developers have to wait for AWS Lambda to dispose and recreate a runtime environment to pickup a change
+        // this approach is less flexible but more performant than reading the value of the environment variable at each invocation
+        var log = logger
+        log.logLevel = Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? .info        
         self.logger = logger
     }
 
@@ -54,11 +60,6 @@ public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: St
         guard let handler else {
             throw LambdaRuntimeError(code: .runtimeCanOnlyBeStartedOnce)
         }
-
-        // by setting the log level here, we understand it can not be changed dynamically at runtime
-        // developers have to wait for AWS Lambda to dispose and recreate a runtime environment to pickup a change
-        // this approach is less flexible but more performant than reading the value of the environment variable at each invocation
-        self.logger.logLevel = Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? .info
 
         try await LambdaRuntimeClient.withRuntimeClient(
             configuration: .init(ip: ip, port: port),

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -38,7 +38,7 @@ public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: St
         // developers have to wait for AWS Lambda to dispose and recreate a runtime environment to pickup a change
         // this approach is less flexible but more performant than reading the value of the environment variable at each invocation
         var log = logger
-        log.logLevel = Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? .info        
+        log.logLevel = Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? .info
         self.logger = logger
     }
 


### PR DESCRIPTION
Set the log level to LOG_LEVEL env variable

### Motivation:

LOG_LEVEL environment variable was not used

### Modifications:

I made the following changes to `LambdaRuntime` 
- transform `log` from `let` to `var` (I hope it does not impact Swift 6 language mode) 
- Set the logger logLevel to the value of the ENV varaibale, defaulting to `.info` when the value is incorrect or not set 

By setting the log level at the creation of the runtime, before entering in the loop, I know that a change of the value in the Lambda console will not affect running microVM. Only microVM launched after the change will pick up the new value, which will eventually affect all containers as the Lambda service replaces microVM on a regular basis.

The alternative is to set the log level before each invocation of the user-provided handler.  This approach would be less performant as it would require to read the environment variable at each invocation of the runtime, not only at the start.

This is a tradeoff for performance instead of flexibility. 

### Result:

It is now possible to write `context.logger.debug("..")` and read the line in CloudWatch logs