### PR TITLE
Adds default devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+    "name": "Swift",
+    "image": "swift:6.0",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "vscode",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+        }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "sswg.swift-lang"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Package.resolved
 .serverless
 .vscode
 Makefile
+.devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ Package.resolved
 .serverless
 .vscode
 Makefile
-.devcontainer


### PR DESCRIPTION
Adds default devcontainer configuration from SSWG: https://github.com/swift-server/swift-devcontainer-template

### Motivation:

Developing for linux can be challenging on macOS because some APIs are not available on linux. By using VSCode and devcontainer you can essentially develop "on linux".

### Modifications:

Adds devcontainer config.

### Result:

When working in VSCode, you can now easily open the project inside a devcontainer.
