### PR TITLE
Explicitly only use `FoundationEssentials` where possible

### DIFF
--- a/Examples/BackgroundTasks/Sources/main.swift
+++ b/Examples/BackgroundTasks/Sources/main.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import AWSLambdaRuntime
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 struct BackgroundProcessingHandler: LambdaWithBackgroundProcessingHandler {
     struct Input: Decodable {

--- a/Examples/BackgroundTasks/Sources/main.swift
+++ b/Examples/BackgroundTasks/Sources/main.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AWSLambdaRuntime
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/AWSLambdaRuntime/Context+Foundation.swift
+++ b/Sources/AWSLambdaRuntime/Context+Foundation.swift
@@ -14,7 +14,11 @@
 
 import AWSLambdaRuntimeCore
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import struct Foundation.Date
+#endif
 
 extension LambdaContext {
     var deadlineDate: Date {

--- a/Sources/AWSLambdaRuntime/Vendored/ByteBuffer-foundation.swift
+++ b/Sources/AWSLambdaRuntime/Vendored/ByteBuffer-foundation.swift
@@ -26,12 +26,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
 
 // This is NIO's `NIOFoundationCompat` module which at the moment only adds `ByteBuffer` utility methods
 // for Foundation's `Data` type.

--- a/Sources/AWSLambdaRuntime/Vendored/ByteBuffer-foundation.swift
+++ b/Sources/AWSLambdaRuntime/Vendored/ByteBuffer-foundation.swift
@@ -26,7 +26,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOCore
 
 // This is NIO's `NIOFoundationCompat` module which at the moment only adds `ByteBuffer` utility methods

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntime.swift
@@ -12,14 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
+import NIOConcurrencyHelpers
+import NIOCore
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import Logging
-import NIOConcurrencyHelpers
-import NIOCore
 
 // We need `@unchecked` Sendable here, as `NIOLockedValueBox` does not understand `sending` today.
 // We don't want to use `NIOLockedValueBox` here anyway. We would love to use Mutex here, but this

--- a/Sources/MockServer/main.swift
+++ b/Sources/MockServer/main.swift
@@ -12,15 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
+import NIOCore
+import NIOHTTP1
+import NIOPosix
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
-import NIOHTTP1
-import NIOPosix
-import Dispatch
 
 struct MockServer {
     private let group: EventLoopGroup

--- a/Sources/MockServer/main.swift
+++ b/Sources/MockServer/main.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOCore
 import NIOHTTP1
 import NIOPosix
+import Dispatch
 
 struct MockServer {
     private let group: EventLoopGroup

--- a/Tests/AWSLambdaRuntimeCoreTests/InvocationTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/InvocationTests.swift
@@ -12,15 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOHTTP1
+import Testing
+
+@testable import AWSLambdaRuntimeCore
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOHTTP1
-import Testing
-
-@testable import AWSLambdaRuntimeCore
 
 @Suite
 struct InvocationTest {

--- a/Tests/AWSLambdaRuntimeCoreTests/InvocationTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/InvocationTests.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOHTTP1
 import Testing
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaMockClient.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaMockClient.swift
@@ -13,13 +13,14 @@
 //===----------------------------------------------------------------------===//
 
 import AWSLambdaRuntimeCore
+import Logging
+import NIOCore
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import Logging
-import NIOCore
 
 struct LambdaMockWriter: LambdaRuntimeClientResponseStreamWriter {
     var underlying: LambdaMockClient

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaMockClient.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaMockClient.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import AWSLambdaRuntimeCore
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Logging
 import NIOCore
 

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRequestIDTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRequestIDTests.swift
@@ -12,15 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+import Testing
+
+@testable import AWSLambdaRuntimeCore
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
-import Testing
-
-@testable import AWSLambdaRuntimeCore
 
 @Suite("LambdaRequestID tests")
 struct LambdaRequestIDTest {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRequestIDTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRequestIDTests.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOCore
 import Testing
 
@@ -100,6 +104,7 @@ struct LambdaRequestIDTest {
         #expect(buffer.readableBytes == readableBeforeRead)
     }
 
+    #if os(macOS)
     @Test
     func testInitFromNSStringSuccess() {
         let nsString = NSMutableString(capacity: 16)
@@ -121,6 +126,7 @@ struct LambdaRequestIDTest {
         #expect(requestID?.uuidString == LambdaRequestID(uuidString: nsString as String)?.uuidString)
         #expect(requestID?.uppercased == nsString as String)
     }
+    #endif
 
     @Test
     func testUnparse() {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRunLoopTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRunLoopTests.swift
@@ -12,16 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
 import Logging
 import NIOCore
 import Testing
 
 @testable import AWSLambdaRuntimeCore
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite
 struct LambdaRunLoopTests {

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRunLoopTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRunLoopTests.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Logging
 import NIOCore
 import Testing

--- a/Tests/AWSLambdaRuntimeCoreTests/MockLambdaServer.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/MockLambdaServer.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation  // for JSON
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 import Logging
 import NIOCore
 import NIOHTTP1

--- a/Tests/AWSLambdaRuntimeCoreTests/MockLambdaServer.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/MockLambdaServer.swift
@@ -12,17 +12,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
 import Logging
 import NIOCore
 import NIOHTTP1
 import NIOPosix
 
 @testable import AWSLambdaRuntimeCore
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 func withMockServer<Result>(
     behaviour: some LambdaServerBehavior,

--- a/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/Utils.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension Date {
     var millisSinceEpoch: Int64 {

--- a/readme.md
+++ b/readme.md
@@ -253,7 +253,11 @@ Background tasks allow code to execute asynchronously after the main response ha
 Here is an example of a minimal function that waits 10 seconds after it returned a response but before the handler returns.
 ```swift
 import AWSLambdaRuntime
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 struct BackgroundProcessingHandler: LambdaWithBackgroundProcessingHandler {
     struct Input: Decodable {


### PR DESCRIPTION
We want that the runtime only depends on `FoundationEssentials` where available (ie. on linux) to ensure small binary size. 

### Motivation:

Smaller binary size is good for lambda deployment and cold-start times. The runtime should only depend on `FoundationEssentials`.

### Modifications:

- replace `import Foundation` with `import FoundationEssentials` if `FoundationEssentials` is available.
- I also applied the same treatment to tests to ensure that catch error where tests run on linux and we use API that is only available in `Foundation` which easily happens when you develop on macOS (where always full `Foundation` is available).

### Result:

This should allow builds without linking full `Foundation`.