### PR TITLE
[examples] Fix path settings in the examples' Package.swift

### DIFF
--- a/Examples/APIGateway/Package.swift
+++ b/Examples/APIGateway/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
                 .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events"),
             ],
-            path: "."
+            path: "Sources"
         )
     ]
 )

--- a/Examples/BackgroundTasks/Package.swift
+++ b/Examples/BackgroundTasks/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
             ],
-            path: "."
+            path: "Sources"
         )
     ]
 )

--- a/Examples/CDK/Package.swift
+++ b/Examples/CDK/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
                 .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events"),
             ],
-            path: "."
+            path: "Sources"
         )
     ]
 )

--- a/Examples/HelloWorld/Package.swift
+++ b/Examples/HelloWorld/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
             ],
-            path: "."
+            path: "Sources"
         )
     ]
 )

--- a/Examples/Streaming/Package.swift
+++ b/Examples/Streaming/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
             ],
-            path: "."
+            path: "Sources"
         )
     ]
 )

--- a/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/03-02-05-package.swift
+++ b/Sources/AWSLambdaRuntimeCore/Documentation.docc/Resources/code/03-02-05-package.swift
@@ -20,7 +20,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
             ],
-            path: "."
+            path: "Sources"
         )
     ]
 )


### PR DESCRIPTION
All the `Package.swift` files from the examples use `path: "."` instead of `path: "Sources"` which triggers error messages when users add a `Test` directory.