### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [AWSLambdaRuntime, AWSLambdaRuntimeCore]
+    - documentation_targets: [AWSLambdaRuntimeCore, AWSLambdaRuntime]


### PR DESCRIPTION
Move `AWSLambdaRuntimeCore` as first package because this is where all the doc lives.  This will make `AWSLambdaRuntimeCore` the default on Swift Package Index

