### PR TITLE
[doc] update deployment guide

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/Documentation.docc/Deployment.md
+++ b/Sources/AWSLambdaRuntimeCore/Documentation.docc/Deployment.md
@@ -68,6 +68,9 @@ Here is the content of this guide:
 
    The name of the ZIP file depends on the target name you entered in the `Package.swift` file.
 
+   >[!NOTE]
+   > When building on Linux, your current user must have permission to use docker. On most Linux distributions, you can do so by adding your user to the `docker` group with the following command: `sudo usermod -aG docker $USER`. You must log out and log back in for the changes to take effect.
+
 ## Choosing the AWS Region where to deploy
 
 [AWS Global infrastructure](https://aws.amazon.com/about-aws/global-infrastructure/) spans over 34 geographic Regions (and continuously expanding). When you create a resource on AWS, such as a Lambda function, you have to select a geographic region where the resource will be created. The two main factors to consider to select a Region are the physical proximity with your users and geographical compliance. 


### PR DESCRIPTION
Add a note in the deployment guide to inform Linux user they must have correct permissions to use docker on their system.

### Motivation:

Build instructions fail on a fresh Ubuntu installation. See this error report.
https://github.com/swift-server/swift-aws-lambda-runtime/issues/449

### Modifications:

Add a note in the deployment guide that Linux user must add their user in the `docker` group.

### Result:

Hopefully, Linux users will not experience error at first use of `swift package archive`
