### PR TITLE
[core] Add cancellation handling for nextInvocation()

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -145,22 +145,28 @@ final actor LambdaRuntimeClient: LambdaRuntimeClientProtocol {
     }
 
     func nextInvocation() async throws -> (Invocation, Writer) {
-        switch self.lambdaState {
-        case .idle:
-            self.lambdaState = .waitingForNextInvocation
-            let handler = try await self.makeOrGetConnection()
-            let invocation = try await handler.nextInvocation()
-            guard case .waitingForNextInvocation = self.lambdaState else {
+        try await withTaskCancellationHandler {
+            switch self.lambdaState {
+            case .idle:
+                self.lambdaState = .waitingForNextInvocation
+                let handler = try await self.makeOrGetConnection()
+                let invocation = try await handler.nextInvocation()
+                guard case .waitingForNextInvocation = self.lambdaState else {
+                    fatalError("Invalid state: \(self.lambdaState)")
+                }
+                self.lambdaState = .waitingForResponse(requestID: invocation.metadata.requestID)
+                return (invocation, Writer(runtimeClient: self))
+
+            case .waitingForNextInvocation,
+                .waitingForResponse,
+                .sendingResponse,
+                .sentResponse:
                 fatalError("Invalid state: \(self.lambdaState)")
             }
-            self.lambdaState = .waitingForResponse(requestID: invocation.metadata.requestID)
-            return (invocation, Writer(runtimeClient: self))
-
-        case .waitingForNextInvocation,
-            .waitingForResponse,
-            .sendingResponse,
-            .sentResponse:
-            fatalError("Invalid state: \(self.lambdaState)")
+        } onCancel: {
+            Task {
+                await self.close()
+            }
         }
     }
 
@@ -469,37 +475,10 @@ private final class LambdaChannelHandler<Delegate: LambdaChannelHandlerDelegate>
     func nextInvocation(isolation: isolated (any Actor)? = #isolation) async throws -> Invocation {
         switch self.state {
         case .connected(let context, .idle):
-            return try await withTaskCancellationHandler {
-                try Task.checkCancellation()
-                return try await withCheckedThrowingContinuation {
-                    (continuation: CheckedContinuation<Invocation, any Error>) in
-                    self.state = .connected(context, .waitingForNextInvocation(continuation))
-
-                    let unsafeContext = NIOLoopBound(context, eventLoop: context.eventLoop)
-                    context.eventLoop.execute { [nextInvocationPath, defaultHeaders] in
-                        // Send next request. The function `sendNextRequest` requires `self` which is not
-                        // Sendable so just inlined the code instead
-                        let httpRequest = HTTPRequestHead(
-                            version: .http1_1,
-                            method: .GET,
-                            uri: nextInvocationPath,
-                            headers: defaultHeaders
-                        )
-                        let context = unsafeContext.value
-                        context.write(Self.wrapOutboundOut(.head(httpRequest)), promise: nil)
-                        context.write(Self.wrapOutboundOut(.end(nil)), promise: nil)
-                        context.flush()
-                    }
-                }
-            } onCancel: {
-                switch self.state {
-                case .connected(_, .waitingForNextInvocation(let continuation)):
-                    continuation.resume(throwing: CancellationError())
-                case .connected(_, .idle):
-                    break
-                default:
-                    fatalError("Invalid state: \(self.state)")
-                }
+            return try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Invocation, any Error>) in
+                self.state = .connected(context, .waitingForNextInvocation(continuation))
+                self.sendNextRequest(context: context)
             }
 
         case .connected(_, .sendingResponse),
@@ -846,6 +825,12 @@ extension LambdaChannelHandler: ChannelInboundHandler {
 
     func channelInactive(context: ChannelHandlerContext) {
         // fail any pending responses with last error or assume peer disconnected
+        switch self.state {
+        case .connected(_, .waitingForNextInvocation(let continuation)):
+            continuation.resume(throwing: self.lastError ?? ChannelError.ioOnClosedChannel)
+        default:
+            break
+        }
 
         // we don't need to forward channelInactive to the delegate, as the delegate observes the
         // closeFuture

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaRuntimeClientTests.swift
@@ -123,8 +123,8 @@ struct LambdaRuntimeClientTests {
                 try await withThrowingTaskGroup(of: Void.self) { group in
                     group.addTask {
                         while true {
-                            print("Waiting")
                             let (_, writer) = try await runtimeClient.nextInvocation()
+                            // Wrap this is a task so cancellation isn't propagated to the write calls
                             try await Task {
                                 try await writer.write(ByteBuffer(string: "hello"))
                                 try await writer.finish()


### PR DESCRIPTION
Allow `LambdaChannelHandler.nextInvocation` to be cancelled.

### Motivation:

If we want to use ServiceLifecycle with the lambda runtime the lambda runtime needs to be cancellable either via a ServiceLifecycle graceful shutdown or via Task cancellation. To avoid bringing in the ServiceLifecycle dependency this PR adds cancellation via Task cancellation handler.

### Modifications:

Add `withTaskCancellationHandler` to nextInvocation which calls close on cancel. 
In `LambdaChannelHandler.channelInactive` resume continuation if state is `waitingForNextInvocation`
Added `LambdaRuntimeClientTests.testCancellation`

### Result:

You can now cancel the runtime while it is waiting for the next invocation.
