### PR TITLE
[plugin] support for resources packaging on ubuntu

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -19,6 +19,11 @@ on:
         type: boolean
         description: "Boolean to enable the compilation of examples. Defaults to true."
         default: true
+      archive_plugin_examples:
+        type: string
+        description: "The list of examples to run through the archive plugin test. Pass a String with a valid JSON array such as \"[ 'HelloWorld', 'APIGateway' ]\""
+        required: true
+        default: ""
       archive_plugin_enabled:
         type: boolean
         description: "Boolean to enable the test of the archive plugin. Defaults to true."
@@ -54,7 +59,7 @@ jobs:
         # We are using only one Swift version
         swift:
           - image: ${{ inputs.matrix_linux_swift_container_image }}
-            swift_version: "6.0.1-amazonlinux2"
+            swift_version: "6.0.3-amazonlinux2"
     container:
       image: ${{ matrix.swift.image }}
     steps:
@@ -98,6 +103,10 @@ jobs:
     name: Test archive plugin
     if: ${{ inputs.archive_plugin_enabled }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        examples: ${{ fromJson(inputs.archive_plugin_examples) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,8 +116,10 @@ jobs:
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: Test the archive plugin
+        env:
+          EXAMPLE: ${{ matrix.examples }}
         run: |
-          .github/workflows/scripts/check-archive-plugin.sh
+            .github/workflows/scripts/check-archive-plugin.sh
 
   check-foundation:
     name: No dependencies on Foundation

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,8 +36,8 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'ResourcePackaging', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
-      archive_plugin_examples: "[ 'HelloWorld', 'ResourcePackaging' ]"
+      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'ResourcesPackaging', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
+      archive_plugin_examples: "[ 'HelloWorld', 'ResourcesPackaging' ]"
       archive_plugin_enabled: true
 
   swift-6-language-mode:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,7 +36,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
+      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'ResourcesPackaging', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
 
       archive_plugin_enabled: true
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,8 +36,8 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'ResourcesPackaging', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
-
+      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'ResourcePackaging', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
+      archive_plugin_examples: "[ 'HelloWorld', 'ResourcePackaging' ]"
       archive_plugin_enabled: true
 
   swift-6-language-mode:

--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -13,25 +13,40 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-EXAMPLE=HelloWorld
-OUTPUT_DIR=.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager
-OUTPUT_FILE=${OUTPUT_DIR}/MyLambda/bootstrap
-ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
+check_archive_plugin() {
+    local EXAMPLE=$1
+    OUTPUT_DIR=.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager
+    OUTPUT_FILE=${OUTPUT_DIR}/MyLambda/bootstrap
+    ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 
-pushd Examples/${EXAMPLE} || exit 1
+    pushd Examples/${EXAMPLE} || exit 1
 
-# package the example (docker and swift toolchain are installed on the GH runner)
-LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker || exit 1
+    # package the example (docker and swift toolchain are installed on the GH runner)
+    LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker || exit 1
 
-# did the plugin generated a Linux binary?
-[ -f "${OUTPUT_FILE}" ]
-file "${OUTPUT_FILE}" | grep --silent ELF
+    # did the plugin generated a Linux binary?
+    [ -f "${OUTPUT_FILE}" ]
+    file "${OUTPUT_FILE}" | grep --silent ELF
 
-# did the plugin created a ZIP file?
-[ -f "${ZIP_FILE}" ]
+    # did the plugin created a ZIP file?
+    [ -f "${ZIP_FILE}" ]
 
-# does the ZIP file contain the bootstrap?
-unzip -l "${ZIP_FILE}" | grep --silent bootstrap
+    # does the ZIP file contain the bootstrap?
+    unzip -l "${ZIP_FILE}" | grep --silent bootstrap
 
-echo "✅ The archive plugin is OK"
-popd || exit 1
+    # if EXAMPLE is ResourcesPackaging, check if the ZIP file contains hello.txt
+    if [ "$EXAMPLE" == "ResourcesPackaging" ]; then
+        unzip -l "${ZIP_FILE}" | grep --silent hello.txt
+    fi    
+
+    echo "✅ The archive plugin is OK with example ${EXAMPLE}"
+    popd || exit 1
+}
+
+# List of examples
+EXAMPLES=("HelloWorld" "ResourcesPackaging")
+
+# Iterate over each example and call check_archive_plugin
+for EXAMPLE in "${EXAMPLES[@]}"; do
+  check_archive_plugin "$EXAMPLE"
+done

--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -19,7 +19,7 @@ check_archive_plugin() {
     OUTPUT_FILE=${OUTPUT_DIR}/MyLambda/bootstrap
     ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 
-    pushd Examples/${EXAMPLE} || exit 1
+    pushd "Examples/${EXAMPLE}" || exit 1
 
     # package the example (docker and swift toolchain are installed on the GH runner)
     LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker || exit 1

--- a/.licenseignore
+++ b/.licenseignore
@@ -34,3 +34,4 @@ Package.resolved
 *.yml
 **/.npmignore
 **/*.json
+**/*.txt

--- a/Examples/ResourcesPackaging/.gitignore
+++ b/Examples/ResourcesPackaging/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Examples/ResourcesPackaging/Package.swift
+++ b/Examples/ResourcesPackaging/Package.swift
@@ -7,21 +7,21 @@ let package = Package(
     name: "ResourcesPackaging",
     platforms: [.macOS(.v15)],
     products: [
-        .executable(name: "MyLambda", targets: ["MyLambda"]),
+        .executable(name: "MyLambda", targets: ["MyLambda"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main")
     ],
     targets: [
         .executableTarget(
             name: "MyLambda",
             dependencies: [
-                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
+                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
             ],
             path: ".",
             resources: [
-                .process("hello.txt"),
+                .process("hello.txt")
             ]
-        ),
+        )
     ]
 )

--- a/Examples/ResourcesPackaging/Package.swift
+++ b/Examples/ResourcesPackaging/Package.swift
@@ -3,6 +3,9 @@
 
 import PackageDescription
 
+// needed for CI to test the local version of the library
+import struct Foundation.URL
+
 let package = Package(
     name: "ResourcesPackaging",
     platforms: [.macOS(.v15)],
@@ -25,3 +28,30 @@ let package = Package(
         )
     ]
 )
+
+if let localDepsPath = Context.environment["LAMBDA_USE_LOCAL_DEPS"],
+    localDepsPath != "",
+    let v = try? URL(fileURLWithPath: localDepsPath).resourceValues(forKeys: [.isDirectoryKey]),
+    v.isDirectory == true
+{
+    // when we use the local runtime as deps, let's remove the dependency added above
+    let indexToRemove = package.dependencies.firstIndex { dependency in
+        if case .sourceControl(
+            name: _,
+            location: "https://github.com/swift-server/swift-aws-lambda-runtime.git",
+            requirement: _
+        ) = dependency.kind {
+            return true
+        }
+        return false
+    }
+    if let indexToRemove {
+        package.dependencies.remove(at: indexToRemove)
+    }
+
+    // then we add the dependency on LAMBDA_USE_LOCAL_DEPS' path (typically ../..)
+    print("[INFO] Compiling against swift-aws-lambda-runtime located at \(localDepsPath)")
+    package.dependencies += [
+        .package(name: "swift-aws-lambda-runtime", path: localDepsPath)
+    ]
+}

--- a/Examples/ResourcesPackaging/Package.swift
+++ b/Examples/ResourcesPackaging/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ResourcesPackaging",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "MyLambda", targets: ["MyLambda"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyLambda",
+            dependencies: [
+                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
+            ],
+            path: ".",
+            resources: [
+                .process("hello.txt"),
+            ]
+        ),
+    ]
+)

--- a/Examples/ResourcesPackaging/Sources/main.swift
+++ b/Examples/ResourcesPackaging/Sources/main.swift
@@ -17,10 +17,10 @@ import Foundation
 
 let runtime = LambdaRuntime {
     (event: String, context: LambdaContext) in
-        guard let fileURL = Bundle.module.url(forResource: "hello", withExtension: "txt") else {
-            fatalError("no file url")
-        }
-        return try String(contentsOf: fileURL, encoding: .utf8)
+    guard let fileURL = Bundle.module.url(forResource: "hello", withExtension: "txt") else {
+        fatalError("no file url")
+    }
+    return try String(contentsOf: fileURL, encoding: .utf8)
 }
 
 try await runtime.run()

--- a/Examples/ResourcesPackaging/Sources/main.swift
+++ b/Examples/ResourcesPackaging/Sources/main.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSLambdaRuntime
+import Foundation
+
+let runtime = LambdaRuntime {
+    (event: String, context: LambdaContext) in
+        guard let fileURL = Bundle.module.url(forResource: "hello", withExtension: "txt") else {
+            fatalError("no file url")
+        }
+        return try String(contentsOf: fileURL, encoding: .utf8)
+}
+
+try await runtime.run()

--- a/Examples/ResourcesPackaging/hello.txt
+++ b/Examples/ResourcesPackaging/hello.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/scripts/test-plugin-ubuntu.sh
+++ b/scripts/test-plugin-ubuntu.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftAWSLambdaRuntime open source project
+##
+## Copyright (c) 2025 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+sudo apt update && sudo apt -y upgrade
+
+# Install Swift 6.0.3
+sudo apt-get -y install \
+          binutils \
+          git \
+          gnupg2 \
+          libc6-dev \
+          libcurl4-openssl-dev \
+          libedit2 \
+          libgcc-13-dev \
+          libncurses-dev \
+          libpython3-dev \
+          libsqlite3-0 \
+          libstdc++-13-dev \
+          libxml2-dev \
+          libz3-dev \
+          pkg-config \
+          tzdata \
+          unzip \
+          zip \
+          zlib1g-dev
+
+wget https://download.swift.org/swift-6.0.3-release/ubuntu2404-aarch64/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-ubuntu24.04-aarch64.tar.gz
+
+tar xfvz swift-6.0.3-RELEASE-ubuntu24.04-aarch64.tar.gz
+
+export PATH=/home/ubuntu/swift-6.0.3-RELEASE-ubuntu24.04-aarch64/usr/bin:"${PATH}"
+
+swift --version
+
+# Install Docker
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Add the current user to the docker group
+sudo usermod -aG docker $USER
+
+# LOGOUT and LOGIN to apply the changes
+exit
+
+# reconnect with ssh 
+
+export PATH=/home/ubuntu/swift-6.0.3-RELEASE-ubuntu24.04-aarch64/usr/bin:"${PATH}"
+
+# clone a project 
+git clone https://github.com/swift-server/swift-aws-lambda-runtime.git
+
+# build the project
+cd swift-aws-lambda-runtime/Examples/ResourcesPackaging/
+LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker                                      

--- a/scripts/ubuntu-install-swift.sh
+++ b/scripts/ubuntu-install-swift.sh
@@ -53,10 +53,11 @@ sudo chmod a+r /etc/apt/keyrings/docker.asc
 
 # Add the repository to Apt sources:
 # shellcheck source=/etc/os-release
+# shellcheck disable=SC1091
 . /etc/os-release
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-  "$VERSION_CODENAME" stable" | \
+  $VERSION_CODENAME stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
 

--- a/scripts/ubuntu-install-swift.sh
+++ b/scripts/ubuntu-install-swift.sh
@@ -61,7 +61,7 @@ sudo apt-get update
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Add the current user to the docker group
-sudo usermod -aG docker $USER
+sudo usermod -aG docker "$USER"
 
 # LOGOUT and LOGIN to apply the changes
 exit

--- a/scripts/ubuntu-install-swift.sh
+++ b/scripts/ubuntu-install-swift.sh
@@ -52,9 +52,11 @@ sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyring
 sudo chmod a+r /etc/apt/keyrings/docker.asc
 
 # Add the repository to Apt sources:
+# shellcheck source=/etc/os-release
+. /etc/os-release
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  "$VERSION_CODENAME" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
 

--- a/scripts/ubuntu-install-swift.sh
+++ b/scripts/ubuntu-install-swift.sh
@@ -64,15 +64,4 @@ sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plug
 sudo usermod -aG docker "$USER"
 
 # LOGOUT and LOGIN to apply the changes
-exit
-
-# reconnect with ssh 
-
-export PATH=/home/ubuntu/swift-6.0.3-RELEASE-ubuntu24.04-aarch64/usr/bin:"${PATH}"
-
-# clone a project 
-git clone https://github.com/swift-server/swift-aws-lambda-runtime.git
-
-# build the project
-cd swift-aws-lambda-runtime/Examples/ResourcesPackaging/
-LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker                                      
+exit 0

--- a/scripts/ubuntu-test-plugin.sh
+++ b/scripts/ubuntu-test-plugin.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftAWSLambdaRuntime open source project
+##
+## Copyright (c) 2025 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# Connect with ssh 
+
+export PATH=/home/ubuntu/swift-6.0.3-RELEASE-ubuntu24.04-aarch64/usr/bin:"${PATH}"
+
+# clone a project 
+git clone https://github.com/swift-server/swift-aws-lambda-runtime.git
+
+# be sure Swift is install.  
+# Youc an install swift with the following command: ./scripts/ubuntu-install-swift.sh
+
+# build the project
+cd swift-aws-lambda-runtime/Examples/ResourcesPackaging/ || exit 1
+LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker                                      


### PR DESCRIPTION
When including resources in the package and packaging on Ubuntu, `FileManager` throws a FilePermission error. The docker daemon runs as root and files to be copied are owned by `root` while the archiver runs as the current user (`ubuntu`  on EC2 Ubuntu). The `FileManager` manages to copy the files but throws an error after the copy. We suspect the `FileManager` to perform some kind of operation after the copy and it fails because of the `root` permission of the files. 

See https://github.com/swift-server/swift-aws-lambda-runtime/issues/449#issuecomment-2595978246 for a description of the problem.

This PR contains code to reproduce the problem, a very simple workaround, and an integration test.
The workaround consists of 
- trapping all errors
- verify if the error is the permission error (Code = 513)
- verify if the files have been copied or not 
- if the two above conditions are met, ignore the error, otherwise re-throw it 

I would rather prefer a solution that solves the root cause rather than just ignoring the error.
We're still investigating the root cause (see [this thread](https://forums.swift.org/t/filemanager-copyitem-on-linux-fails-after-copying-the-files/77282) on the Swift Forum and this issue on Swift Foundation https://github.com/swiftlang/swift-foundation/issues/1125