### PR TITLE
[examples] Update to Swift Lambda Events 1.0.0

### DIFF
--- a/Examples/APIGateway+LambdaAuthorizer/Package.swift
+++ b/Examples/APIGateway+LambdaAuthorizer/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // during CI, the dependency on local version of swift-aws-lambda-runtime is added dynamically below
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/APIGateway/Package.swift
+++ b/Examples/APIGateway/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // during CI, the dependency on local version of swift-aws-lambda-runtime is added dynamically below
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/CDK/Package.swift
+++ b/Examples/CDK/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // during CI, the dependency on local version of swift-aws-lambda-runtime is added dynamically below
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/S3_AWSSDK/Package.swift
+++ b/Examples/S3_AWSSDK/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // during CI, the dependency on local version of swift-aws-lambda-runtime is added dynamically below
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", from: "1.0.0"),
         .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.0.0"),
     ],
     targets: [

--- a/Examples/S3_Soto/Package.swift
+++ b/Examples/S3_Soto/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
 
         // during CI, the dependency on local version of swift-aws-lambda-runtime is added dynamically below
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/Testing/Package.swift
+++ b/Examples/Testing/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // during CI, the dependency on local version of swift-aws-lambda-runtime is added dynamically below
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Now that the swift Lambda event library has been tagged 1.0.0, update all the examples to use `from: "1.0.0"` instead of `main` branch