### PR TITLE
Add `S3EventNotifier` example

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,7 +36,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'ResourcesPackaging', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
+      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'ResourcesPackaging', 'S3EventNotifier', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Testing', 'Tutorial' ]"
       archive_plugin_examples: "[ 'HelloWorld', 'ResourcesPackaging' ]"
       archive_plugin_enabled: true
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -28,6 +28,8 @@ This directory contains example code for Lambda functions.
 
 - **[HelloWorld](HelloWorld/README.md)**: a simple Lambda function (requires [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)).
 
+- **[S3EventNotifier](S3EventNotifier/README.md)**: a Lambda function that receives object-upload notifications from an [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) bucket.
+
 - **[S3_AWSSDK](S3_AWSSDK/README.md)**: a Lambda function that uses the [AWS SDK for Swift](https://docs.aws.amazon.com/sdk-for-swift/latest/developer-guide/getting-started.html) to invoke an [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) API (requires [AWS SAM](https://aws.amazon.com/serverless/sam/)).
 
 - **[S3_Soto](S3_Soto/README.md)**: a Lambda function that uses [Soto](https://github.com/soto-project/soto) to invoke an [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) API (requires [AWS SAM](https://aws.amazon.com/serverless/sam/)).

--- a/Examples/S3EventNotifier/.gitignore
+++ b/Examples/S3EventNotifier/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/.index-build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Examples/S3EventNotifier/Package.swift
+++ b/Examples/S3EventNotifier/Package.swift
@@ -1,0 +1,52 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+// needed for CI to test the local version of the library
+import struct Foundation.URL
+
+let package = Package(
+    name: "CSVUploadAPINotificationLambda",
+    platforms: [.macOS(.v15)],
+    dependencies: [
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CSVUploadAPINotificationLambda",
+            dependencies: [
+                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
+                .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            ]
+        )
+    ]
+)
+
+if let localDepsPath = Context.environment["LAMBDA_USE_LOCAL_DEPS"],
+    localDepsPath != "",
+    let v = try? URL(fileURLWithPath: localDepsPath).resourceValues(forKeys: [.isDirectoryKey]),
+    v.isDirectory == true
+{
+    // when we use the local runtime as deps, let's remove the dependency added above
+    let indexToRemove = package.dependencies.firstIndex { dependency in
+        if case .sourceControl(
+            name: _,
+            location: "https://github.com/swift-server/swift-aws-lambda-runtime.git",
+            requirement: _
+        ) = dependency.kind {
+            return true
+        }
+        return false
+    }
+    if let indexToRemove {
+        package.dependencies.remove(at: indexToRemove)
+    }
+
+    // then we add the dependency on LAMBDA_USE_LOCAL_DEPS' path (typically ../..)
+    print("[INFO] Compiling against swift-aws-lambda-runtime located at \(localDepsPath)")
+    package.dependencies += [
+        .package(name: "swift-aws-lambda-runtime", path: localDepsPath)
+    ]
+}

--- a/Examples/S3EventNotifier/Package.swift
+++ b/Examples/S3EventNotifier/Package.swift
@@ -5,20 +5,18 @@ import PackageDescription
 import struct Foundation.URL
 
 let package = Package(
-    name: "CSVUploadAPINotificationLambda",
+    name: "S3EventNotifier",
     platforms: [.macOS(.v15)],
     dependencies: [
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0"),
     ],
     targets: [
         .executableTarget(
-            name: "CSVUploadAPINotificationLambda",
+            name: "S3EventNotifier",
             dependencies: [
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
                 .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events"),
-                .product(name: "AsyncHTTPClient", package: "async-http-client"),
             ]
         )
     ]

--- a/Examples/S3EventNotifier/README.md
+++ b/Examples/S3EventNotifier/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to write a Lambda that is invoked by an event orig
 
 ## Code
 
-In this example the lambda function receives an `S3Event` object defined in the `AWSLambdaEvents` library as input object. The `S3Event` object contains all the information about the S3 event that triggered the function, but what we are interested in is the bucket name and the object key, which are inside of a notification `Record`. The object contains an array of records, however since the lambda is triggered by a single event, we can safely assume that there is only one record in the array: the first one. Inside of this record, we can find the bucket name and the object key:
+In this example the Lambda function receives an `S3Event` object defined in the `AWSLambdaEvents` library as input object. The `S3Event` object contains all the information about the S3 event that triggered the function, but what we are interested in is the bucket name and the object key, which are inside of a notification `Record`. The object contains an array of records, however since the Lambda function is triggered by a single event, we can safely assume that there is only one record in the array: the first one. Inside of this record, we can find the bucket name and the object key:
 
 ```swift
 guard let s3NotificationRecord = event.records.first else {
@@ -46,13 +46,13 @@ The `--architectures` flag is only required when you build the binary on an Appl
 
 Be sure to replace `<YOUR_ACCOUNT_ID>` with your actual AWS account ID (for example: 012345678901).
 
-Besides deploying the lambda function you also need to create the S3 bucket and configure it to send events to the lambda function. You can do this using the following commands:
+Besides deploying the Lambda function you also need to create the S3 bucket and configure it to send events to the Lambda function. You can do this using the following commands:
 
 ```bash
 aws s3api create-bucket --bucket my-test-bucket --region eu-west-1 --create-bucket-configuration LocationConstraint=eu-west-1
 
 aws lambda add-permission \
-    --function-name ProcessS3Upload \
+    --function-name S3EventNotifier \
     --statement-id S3InvokeFunction \
     --action lambda:InvokeFunction \
     --principal s3.amazonaws.com \
@@ -62,7 +62,7 @@ aws s3api put-bucket-notification-configuration \
     --bucket my-test-bucket \
     --notification-configuration '{
         "LambdaFunctionConfigurations": [{
-            "LambdaFunctionArn": "arn:aws:lambda:<REGION>:<YOUR_ACCOUNT_ID>:function:ProcessS3Upload",
+            "LambdaFunctionArn": "arn:aws:lambda:<REGION>:<YOUR_ACCOUNT_ID>:function:S3EventNotifier",
             "Events": ["s3:ObjectCreated:*"]
         }]
     }'
@@ -72,8 +72,8 @@ aws s3 cp testfile.txt s3://my-test-bucket/
 
 This will:
  - create a bucket named `my-test-bucket` in the `eu-west-1` region;
- - add a permission to the lambda function to be invoked by the bucket;
- - configure the bucket to send `s3:ObjectCreated:*` events to the lambda function named `ProcessS3Upload`;
+ - add a permission to the Lambda function to be invoked by Amazon S3;
+ - configure the bucket to send `s3:ObjectCreated:*` events to the Lambda function named `S3EventNotifier`;
  - upload a file named `testfile.txt` to the bucket.
 
-Replace `<REGION>` with the region where you deployed the lambda function and `<YOUR_ACCOUNT_ID>` with your actual AWS account ID.
+Replace `<REGION>` with the region where you deployed the Lambda function and `<YOUR_ACCOUNT_ID>` with your actual AWS account ID.

--- a/Examples/S3EventNotifier/README.md
+++ b/Examples/S3EventNotifier/README.md
@@ -30,8 +30,8 @@ If there are no errors, a ZIP file should be ready to deploy, located at `.build
 
 ## Deploy
 
-[!IMPORTANT]
-The Lambda function and the S3 bucket must be located in the same AWS Region. In the code below, we use `eu-west-1` (Ireland). 
+> [!IMPORTANT]
+> The Lambda function and the S3 bucket must be located in the same AWS Region. In the code below, we use `eu-west-1` (Ireland). 
 
 To deploy the Lambda function, you can use the `aws` command line:
 
@@ -90,5 +90,5 @@ This will:
 
 Replace `my-test-bucket` with your bucket name (bucket names are unique globaly and this one is already taken). Also replace `REGION` environment variable with the AWS Region where you deployed the Lambda function and `<YOUR_ACCOUNT_ID>` with your actual AWS account ID.
 
-[!IMPORTANT]
-The Lambda function and the S3 bucket must be located in the same AWS Region. Adjust the code above according to your closest AWS Region.
+> [!IMPORTANT]
+> The Lambda function and the S3 bucket must be located in the same AWS Region. Adjust the code above according to your closest AWS Region.

--- a/Examples/S3EventNotifier/README.md
+++ b/Examples/S3EventNotifier/README.md
@@ -1,0 +1,52 @@
+# S3 Event Notifier
+
+This example demonstrates how to create a Lambda that notifies an API of an S3 event in a bucket.
+
+## Code
+
+In this example the lambda function receives an `S3Event` object from the `AWSLambdaEvents` library as input object instead of a `APIGatewayV2Request`. The `S3Event` object contains all the information about the S3 event that triggered the lambda, but what we are interested in is the bucket name and the object key, which are inside of a notification `Record`. The object contains an array of records, however since the lambda is triggered by a single event, we can safely assume that there is only one record in the array: the first one. Inside of this record, we can find the bucket name and the object key:
+
+```swift
+guard let s3NotificationRecord = event.records.first else {
+    throw LambdaError.noNotificationRecord
+}
+
+let bucket = s3NotificationRecord.s3.bucket.name
+let key = s3NotificationRecord.s3.object.key.replacingOccurrences(of: "+", with: " ")
+```
+
+The key is URL encoded, so we replace the `+` with a space.
+
+Once the event is decoded, the lambda sends a POST request to an API endpoint with the bucket name and the object key as parameters. The API URL is set as an environment variable.
+
+## Build & Package 
+
+To build & archive the package you can use the following commands:
+
+```bash
+swift build
+swift package archive --allow-network-connections docker
+```
+
+If there are no errors, a ZIP file should be ready to deploy, located at `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/S3EventNotifier/S3EventNotifier.zip`.
+
+## Deploy
+
+To deploy the Lambda function, you can use the `aws` command line:
+
+```bash
+aws lambda create-function \
+--function-name S3EventNotifier \
+--zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/S3EventNotifier/S3EventNotifier.zip \
+--runtime provided.al2 \
+--handler provided  \
+--architectures arm64 \
+--role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution
+```
+
+The `--architectures` flag is only required when you build the binary on an Apple Silicon machine (Apple M1 or more recent). It defaults to `x64`.
+
+Be sure to replace <YOUR_ACCOUNT_ID> with your actual AWS account ID (for example: 012345678901).
+
+> [!WARNING]
+> You will have to set up an S3 bucket and configure it to send events to the lambda function. This is not covered in this example.

--- a/Examples/S3EventNotifier/README.md
+++ b/Examples/S3EventNotifier/README.md
@@ -1,10 +1,10 @@
 # S3 Event Notifier
 
-This example demonstrates how to create a Lambda that notifies an API of an S3 event in a bucket.
+This example demonstrates how to write a Lambda that is invoked by an event originating from Amazon S3, such as a new object being uploaded to a bucket.
 
 ## Code
 
-In this example the lambda function receives an `S3Event` object from the `AWSLambdaEvents` library as input object instead of a `APIGatewayV2Request`. The `S3Event` object contains all the information about the S3 event that triggered the lambda, but what we are interested in is the bucket name and the object key, which are inside of a notification `Record`. The object contains an array of records, however since the lambda is triggered by a single event, we can safely assume that there is only one record in the array: the first one. Inside of this record, we can find the bucket name and the object key:
+In this example the lambda function receives an `S3Event` object defined in the `AWSLambdaEvents` library as input object. The `S3Event` object contains all the information about the S3 event that triggered the function, but what we are interested in is the bucket name and the object key, which are inside of a notification `Record`. The object contains an array of records, however since the lambda is triggered by a single event, we can safely assume that there is only one record in the array: the first one. Inside of this record, we can find the bucket name and the object key:
 
 ```swift
 guard let s3NotificationRecord = event.records.first else {
@@ -16,8 +16,6 @@ let key = s3NotificationRecord.s3.object.key.replacingOccurrences(of: "+", with:
 ```
 
 The key is URL encoded, so we replace the `+` with a space.
-
-Once the event is decoded, the lambda sends a POST request to an API endpoint with the bucket name and the object key as parameters. The API URL is set as an environment variable.
 
 ## Build & Package 
 
@@ -36,17 +34,46 @@ To deploy the Lambda function, you can use the `aws` command line:
 
 ```bash
 aws lambda create-function \
---function-name S3EventNotifier \
---zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/S3EventNotifier/S3EventNotifier.zip \
---runtime provided.al2 \
---handler provided  \
---architectures arm64 \
---role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution
+    --function-name S3EventNotifier \
+    --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/S3EventNotifier/S3EventNotifier.zip \
+    --runtime provided.al2 \
+    --handler provided  \
+    --architectures arm64 \
+    --role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution
 ```
 
 The `--architectures` flag is only required when you build the binary on an Apple Silicon machine (Apple M1 or more recent). It defaults to `x64`.
 
-Be sure to replace <YOUR_ACCOUNT_ID> with your actual AWS account ID (for example: 012345678901).
+Be sure to replace `<YOUR_ACCOUNT_ID>` with your actual AWS account ID (for example: 012345678901).
 
-> [!WARNING]
-> You will have to set up an S3 bucket and configure it to send events to the lambda function. This is not covered in this example.
+Besides deploying the lambda function you also need to create the S3 bucket and configure it to send events to the lambda function. You can do this using the following commands:
+
+```bash
+aws s3api create-bucket --bucket my-test-bucket --region eu-west-1 --create-bucket-configuration LocationConstraint=eu-west-1
+
+aws lambda add-permission \
+    --function-name ProcessS3Upload \
+    --statement-id S3InvokeFunction \
+    --action lambda:InvokeFunction \
+    --principal s3.amazonaws.com \
+    --source-arn arn:aws:s3:::my-test-bucket
+
+aws s3api put-bucket-notification-configuration \
+    --bucket my-test-bucket \
+    --notification-configuration '{
+        "LambdaFunctionConfigurations": [{
+            "LambdaFunctionArn": "arn:aws:lambda:<REGION>:<YOUR_ACCOUNT_ID>:function:ProcessS3Upload",
+            "Events": ["s3:ObjectCreated:*"]
+        }]
+    }'
+
+aws s3 cp testfile.txt s3://my-test-bucket/
+```
+
+This will:
+ - create a bucket named `my-test-bucket` in the `eu-west-1` region;
+ - add a permission to the lambda function to be invoked by the bucket;
+ - configure the bucket to send `s3:ObjectCreated:*` events to the lambda function named `ProcessS3Upload`;
+ - upload a file named `testfile.txt` to the bucket.
+
+Replace `<REGION>` with the region where you deployed the lambda function and `<YOUR_ACCOUNT_ID>` with your actual AWS account ID.

--- a/Examples/S3EventNotifier/README.md
+++ b/Examples/S3EventNotifier/README.md
@@ -30,10 +30,14 @@ If there are no errors, a ZIP file should be ready to deploy, located at `.build
 
 ## Deploy
 
+[!IMPORTANT]
+The Lambda function and the S3 bucket must be located in the same AWS Region. In the code below, we use `eu-west-1` (Ireland). 
+
 To deploy the Lambda function, you can use the `aws` command line:
 
 ```bash
 aws lambda create-function \
+    --region eu-west-1 \
     --function-name S3EventNotifier \
     --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/S3EventNotifier/S3EventNotifier.zip \
     --runtime provided.al2 \
@@ -51,7 +55,8 @@ Besides deploying the Lambda function you also need to create the S3 bucket and 
 ```bash
 aws s3api create-bucket --bucket my-test-bucket --region eu-west-1 --create-bucket-configuration LocationConstraint=eu-west-1
 
-aws lambda add-permission \
+aws lambda add-permission 
+    --region eu-west-1 \
     --function-name S3EventNotifier \
     --statement-id S3InvokeFunction \
     --action lambda:InvokeFunction \
@@ -59,6 +64,7 @@ aws lambda add-permission \
     --source-arn arn:aws:s3:::my-test-bucket
 
 aws s3api put-bucket-notification-configuration \
+    --region eu-west-1 \
     --bucket my-test-bucket \
     --notification-configuration '{
         "LambdaFunctionConfigurations": [{
@@ -67,7 +73,7 @@ aws s3api put-bucket-notification-configuration \
         }]
     }'
 
-aws s3 cp testfile.txt s3://my-test-bucket/
+touch testfile.txt && aws s3 cp testfile.txt s3://my-test-bucket/
 ```
 
 This will:
@@ -76,4 +82,7 @@ This will:
  - configure the bucket to send `s3:ObjectCreated:*` events to the Lambda function named `S3EventNotifier`;
  - upload a file named `testfile.txt` to the bucket.
 
-Replace `<REGION>` with the region where you deployed the Lambda function and `<YOUR_ACCOUNT_ID>` with your actual AWS account ID.
+Replace `my-test-bucket` with your bucket name (bucket names are unique globaly and this one is already taken). Also replace `<REGION>` with the region where you deployed the Lambda function and `<YOUR_ACCOUNT_ID>` with your actual AWS account ID.
+
+[!IMPORTANT]
+The Lambda function and the S3 bucket must be located in the same AWS Region. Adjust the code above according to your closest AWS Region.

--- a/Examples/S3EventNotifier/Sources/main.swift
+++ b/Examples/S3EventNotifier/Sources/main.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSLambdaEvents
+import AWSLambdaRuntime
+import AsyncHTTPClient
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+let httpClient = HTTPClient.shared
+
+enum LambdaError: Error {
+    case noNotificationRecord
+    case missingEnvVar(name: String)
+
+    var description: String {
+        switch self {
+        case .noNotificationRecord:
+            "No notification record in S3 event"
+        case .missingEnvVar(let name):
+            "Missing env var named \(name)"
+        }
+    }
+}
+
+let runtime = LambdaRuntime { (event: S3Event, context: LambdaContext) async throws -> APIGatewayV2Response in
+    do {
+        context.logger.debug("Received S3 event: \(event)")
+
+        guard let s3NotificationRecord = event.records.first else {
+            throw LambdaError.noNotificationRecord
+        }
+
+        let bucket = s3NotificationRecord.s3.bucket.name
+        let key = s3NotificationRecord.s3.object.key.replacingOccurrences(of: "+", with: " ")
+
+        guard let apiURL = ProcessInfo.processInfo.environment["API_URL"] else {
+            throw LambdaError.missingEnvVar(name: "API_URL")
+        }
+
+        let body = """
+            {
+                "bucket": "\(bucket)",
+                "key": "\(key)"
+            }
+            """
+
+        context.logger.debug("Sending request to \(apiURL) with body \(body)")
+
+        var request = HTTPClientRequest(url: "\(apiURL)/upload-complete/")
+        request.method = .POST
+        request.headers = [
+            "Content-Type": "application/json"
+        ]
+        request.body = .bytes(.init(string: body))
+
+        let response = try await httpClient.execute(request, timeout: .seconds(30))
+        return APIGatewayV2Response(
+            statusCode: .ok,
+            body: "Lambda terminated successfully. API responded with: Status: \(response.status), Body: \(response.body)"
+        )
+    } catch let error as LambdaError {
+        context.logger.error("\(error.description)")
+        return APIGatewayV2Response(statusCode: .internalServerError, body: "[ERROR] \(error.description)")
+    } catch {
+        context.logger.error("\(error)")
+        return APIGatewayV2Response(statusCode: .internalServerError, body: "[ERROR] \(error)")
+    }
+}
+
+try await runtime.run()

--- a/Examples/S3EventNotifier/Sources/main.swift
+++ b/Examples/S3EventNotifier/Sources/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2024 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -24,63 +24,20 @@ import Foundation
 
 let httpClient = HTTPClient.shared
 
-enum LambdaError: Error {
-    case noNotificationRecord
-    case missingEnvVar(name: String)
+let runtime = LambdaRuntime { (event: S3Event, context: LambdaContext) async throws in
+    context.logger.debug("Received S3 event: \(event)")
 
-    var description: String {
-        switch self {
-        case .noNotificationRecord:
-            "No notification record in S3 event"
-        case .missingEnvVar(let name):
-            "Missing env var named \(name)"
-        }
+    guard let s3NotificationRecord = event.records.first else {
+        context.logger.error("No S3 notification record found in the event")
+        return
     }
-}
 
-let runtime = LambdaRuntime { (event: S3Event, context: LambdaContext) async throws -> APIGatewayV2Response in
-    do {
-        context.logger.debug("Received S3 event: \(event)")
+    let bucket = s3NotificationRecord.s3.bucket.name
+    let key = s3NotificationRecord.s3.object.key.replacingOccurrences(of: "+", with: " ")
 
-        guard let s3NotificationRecord = event.records.first else {
-            throw LambdaError.noNotificationRecord
-        }
+    context.logger.info("Received notification from S3 bucket '\(bucket)' for object with key '\(key)'")
 
-        let bucket = s3NotificationRecord.s3.bucket.name
-        let key = s3NotificationRecord.s3.object.key.replacingOccurrences(of: "+", with: " ")
-
-        guard let apiURL = ProcessInfo.processInfo.environment["API_URL"] else {
-            throw LambdaError.missingEnvVar(name: "API_URL")
-        }
-
-        let body = """
-            {
-                "bucket": "\(bucket)",
-                "key": "\(key)"
-            }
-            """
-
-        context.logger.debug("Sending request to \(apiURL) with body \(body)")
-
-        var request = HTTPClientRequest(url: "\(apiURL)/upload-complete/")
-        request.method = .POST
-        request.headers = [
-            "Content-Type": "application/json"
-        ]
-        request.body = .bytes(.init(string: body))
-
-        let response = try await httpClient.execute(request, timeout: .seconds(30))
-        return APIGatewayV2Response(
-            statusCode: .ok,
-            body: "Lambda terminated successfully. API responded with: Status: \(response.status), Body: \(response.body)"
-        )
-    } catch let error as LambdaError {
-        context.logger.error("\(error.description)")
-        return APIGatewayV2Response(statusCode: .internalServerError, body: "[ERROR] \(error.description)")
-    } catch {
-        context.logger.error("\(error)")
-        return APIGatewayV2Response(statusCode: .internalServerError, body: "[ERROR] \(error)")
-    }
+    // Here you could, for example, notify an API or a messaging service
 }
 
 try await runtime.run()

--- a/Examples/S3EventNotifier/Sources/main.swift
+++ b/Examples/S3EventNotifier/Sources/main.swift
@@ -15,6 +15,12 @@
 import AWSLambdaEvents
 import AWSLambdaRuntime
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 let runtime = LambdaRuntime { (event: S3Event, context: LambdaContext) async throws in
     context.logger.debug("Received S3 event: \(event)")
 

--- a/Examples/S3EventNotifier/Sources/main.swift
+++ b/Examples/S3EventNotifier/Sources/main.swift
@@ -14,16 +14,9 @@
 
 import AWSLambdaEvents
 import AWSLambdaRuntime
-
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
 import Foundation
-#endif
 
 let runtime = LambdaRuntime { (event: S3Event, context: LambdaContext) async throws in
-    context.logger.debug("Received S3 event: \(event)")
-
     guard let s3NotificationRecord = event.records.first else {
         context.logger.error("No S3 notification record found in the event")
         return

--- a/Examples/S3EventNotifier/Sources/main.swift
+++ b/Examples/S3EventNotifier/Sources/main.swift
@@ -14,15 +14,6 @@
 
 import AWSLambdaEvents
 import AWSLambdaRuntime
-import AsyncHTTPClient
-
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
-let httpClient = HTTPClient.shared
 
 let runtime = LambdaRuntime { (event: S3Event, context: LambdaContext) async throws in
     context.logger.debug("Received S3 event: \(event)")


### PR DESCRIPTION
Add `S3EventNotifier` example

### Motivation:

There is currently no example regarding an AWS event triggered lambda, such as a lambda that gets invoked on an S3 object upload. I've had to look for a while to figure out that the `AWSLambdaEvents` exists and that it can be used for that (had to find out via a Java example! 😜) so I think this could be useful and a somewhat common use case

### Modifications:

Added an example of a lambda that gets triggered when an object gets uploaded to an S3 bucket.

I have not described how to set up the actual S3 event in AWS because I figured if you needed such a lambda you'd know, but I can describe that too in the README if needed
