### PR TITLE
declare user agent string only once

### DIFF
--- a/Sources/AWSLambdaRuntime/ControlPlaneRequestEncoder.swift
+++ b/Sources/AWSLambdaRuntime/ControlPlaneRequestEncoder.swift
@@ -93,7 +93,8 @@ struct ControlPlaneRequestEncoder: _EmittingChannelHandler {
 extension String {
     static let CRLF: String = "\r\n"
 
-    static let userAgentHeader: String = "user-agent: Swift-Lambda/Unknown\r\n"
+    static let userAgent = "Swift-Lambda/Unknown"
+    static let userAgentHeader: String = "user-agent: \(userAgent)\r\n"
     static let unhandledErrorHeader: String = "lambda-runtime-function-error-type: Unhandled\r\n"
 
     static let nextInvocationRequestLine: String =

--- a/Sources/AWSLambdaRuntime/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntimeClient.swift
@@ -458,16 +458,16 @@ private final class LambdaChannelHandler<Delegate: LambdaChannelHandlerDelegate>
         self.configuration = configuration
         self.defaultHeaders = [
             "host": "\(self.configuration.ip):\(self.configuration.port)",
-            "user-agent": "Swift-Lambda/Unknown",
+            "user-agent": .userAgent,
         ]
         self.errorHeaders = [
             "host": "\(self.configuration.ip):\(self.configuration.port)",
-            "user-agent": "Swift-Lambda/Unknown",
+            "user-agent": .userAgent,
             "lambda-runtime-function-error-type": "Unhandled",
         ]
         self.streamingHeaders = [
             "host": "\(self.configuration.ip):\(self.configuration.port)",
-            "user-agent": "Swift-Lambda/Unknown",
+            "user-agent": .userAgent,
             "transfer-encoding": "chunked",
         ]
     }
@@ -638,7 +638,7 @@ private final class LambdaChannelHandler<Delegate: LambdaChannelHandlerDelegate>
                 if byteBuffer?.readableBytes ?? 0 < 6_000_000 {
                     [
                         "host": "\(self.configuration.ip):\(self.configuration.port)",
-                        "user-agent": "Swift-Lambda/Unknown",
+                        "user-agent": .userAgent,
                         "content-length": "\(byteBuffer?.readableBytes ?? 0)",
                     ]
                 } else {

--- a/Tests/AWSLambdaRuntimeCoreTests/ControlPlaneRequestEncoderTests.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/ControlPlaneRequestEncoderTests.swift
@@ -49,7 +49,7 @@ final class ControlPlaneRequestEncoderTests: XCTestCase {
         XCTAssertEqual(request?.head.uri, "/2018-06-01/runtime/invocation/next")
         XCTAssertEqual(request?.head.version, .http1_1)
         XCTAssertEqual(request?.head.headers["host"], [self.host])
-        XCTAssertEqual(request?.head.headers["user-agent"], ["Swift-Lambda/Unknown"])
+        XCTAssertEqual(request?.head.headers["user-agent"], [.userAgent])
 
         XCTAssertNil(try self.server.readInbound(as: NIOHTTPServerRequestFull.self))
     }
@@ -64,7 +64,7 @@ final class ControlPlaneRequestEncoderTests: XCTestCase {
         XCTAssertEqual(request?.head.uri, "/2018-06-01/runtime/invocation/\(requestID)/response")
         XCTAssertEqual(request?.head.version, .http1_1)
         XCTAssertEqual(request?.head.headers["host"], [self.host])
-        XCTAssertEqual(request?.head.headers["user-agent"], ["Swift-Lambda/Unknown"])
+        XCTAssertEqual(request?.head.headers["user-agent"], [.userAgent])
         XCTAssertEqual(request?.head.headers["content-length"], ["0"])
 
         XCTAssertNil(try self.server.readInbound(as: NIOHTTPServerRequestFull.self))
@@ -82,7 +82,7 @@ final class ControlPlaneRequestEncoderTests: XCTestCase {
         XCTAssertEqual(request?.head.uri, "/2018-06-01/runtime/invocation/\(requestID)/response")
         XCTAssertEqual(request?.head.version, .http1_1)
         XCTAssertEqual(request?.head.headers["host"], [self.host])
-        XCTAssertEqual(request?.head.headers["user-agent"], ["Swift-Lambda/Unknown"])
+        XCTAssertEqual(request?.head.headers["user-agent"], [.userAgent])
         XCTAssertEqual(request?.head.headers["content-length"], ["\(payload.readableBytes)"])
         XCTAssertEqual(request?.body, payload)
 
@@ -100,7 +100,7 @@ final class ControlPlaneRequestEncoderTests: XCTestCase {
         XCTAssertEqual(request?.head.uri, "/2018-06-01/runtime/invocation/\(requestID)/error")
         XCTAssertEqual(request?.head.version, .http1_1)
         XCTAssertEqual(request?.head.headers["host"], [self.host])
-        XCTAssertEqual(request?.head.headers["user-agent"], ["Swift-Lambda/Unknown"])
+        XCTAssertEqual(request?.head.headers["user-agent"], [.userAgent])
         XCTAssertEqual(request?.head.headers["lambda-runtime-function-error-type"], ["Unhandled"])
         let expectedBody = #"{"errorType":"SomeError","errorMessage":"An error happened"}"#
 
@@ -123,7 +123,7 @@ final class ControlPlaneRequestEncoderTests: XCTestCase {
         XCTAssertEqual(request?.head.uri, "/2018-06-01/runtime/init/error")
         XCTAssertEqual(request?.head.version, .http1_1)
         XCTAssertEqual(request?.head.headers["host"], [self.host])
-        XCTAssertEqual(request?.head.headers["user-agent"], ["Swift-Lambda/Unknown"])
+        XCTAssertEqual(request?.head.headers["user-agent"], [.userAgent])
         XCTAssertEqual(request?.head.headers["lambda-runtime-function-error-type"], ["Unhandled"])
         let expectedBody = #"{"errorType":"StartupError","errorMessage":"Urgh! Startup failed. 😨"}"#
         XCTAssertEqual(request?.head.headers["content-length"], ["\(expectedBody.utf8.count)"])


### PR DESCRIPTION
The user-agent string was repeated at 5+ different places in the source code.
I defined it as a constant in the `ControlPlaneRequest` struct where other similar constant have been defined and make sure the rest of the code only uses that constant.

This should address https://github.com/swift-server/swift-aws-lambda-runtime/issues/492