### PR TITLE
[ci] : Remove deprecated options on unit-test action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,7 @@ jobs:
       # this currently resolves to 6.2.dev
       # It crashes some of our tests https://github.com/swift-server/swift-aws-lambda-runtime/issues/509
       linux_nightly_main_enabled: true
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,6 +28,7 @@ jobs:
       # this currently resolves to 6.1 nightly
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_enabled: true
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       # this currently resolves to 6.2.dev
       # It crashes some of our tests https://github.com/swift-server/swift-aws-lambda-runtime/issues/509
       linux_nightly_main_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,14 +17,19 @@ jobs:
       format_check_container_image: "swiftlang/swift:nightly-6.1-jammy"
       yamllint_check_enabled: true
 
+  # https://github.com/apple/swift-nio/blob/main/.github/workflows/unit_tests.yml
   unit-tests:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_enabled: true
+      linux_nightly_6_1_enabled: true
+      linux_nightly_next_enabled: true
+      # this currently resolves to 6.2.dev
+      # It crashes some of our tests https://github.com/swift-server/swift-aws-lambda-runtime/issues/509
+      linux_nightly_main_enabled: false
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,7 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: true
       # this currently resolves to 6.1 nightly
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_enabled: true
       # this currently resolves to 6.2.dev
       # It crashes some of our tests https://github.com/swift-server/swift-aws-lambda-runtime/issues/509

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,7 +29,7 @@ jobs:
       linux_nightly_next_enabled: true
       # this currently resolves to 6.2.dev
       # It crashes some of our tests https://github.com/swift-server/swift-aws-lambda-runtime/issues/509
-      linux_nightly_main_enabled: false
+      linux_nightly_main_enabled: true
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
       linux_6_0_enabled: true
-      linux_nightly_6_1_enabled: true
+      # this currently resolves to 6.1 nightly
       linux_nightly_next_enabled: true
       # this currently resolves to 6.2.dev
       # It crashes some of our tests https://github.com/swift-server/swift-aws-lambda-runtime/issues/509


### PR DESCRIPTION
~~Attempt to fix CI~~

Remove usage of deprecated parameters on unit-test. 

- explicitly enable tests on nightly 6.0
- explicitly enable tests on nightly next
- explicitly enable tests on nightly main

At the time of this writing, this resolves to 

```
linux_6_0_container_image="swift:6.0-jammy"
linux_nightly_next_container_image="swiftlang/swift:nightly-6.1-jammy"
linux_nightly_main_container_image="swiftlang/swift:nightly-main-jammy"
```