### PR TITLE
Add inlinable where potentially usefull

### DIFF
--- a/Sources/AWSLambdaRuntime/ControlPlaneRequest.swift
+++ b/Sources/AWSLambdaRuntime/ControlPlaneRequest.swift
@@ -28,12 +28,19 @@ enum ControlPlaneResponse: Hashable {
     case error(ErrorResponse)
 }
 
-package struct InvocationMetadata: Hashable {
+@usableFromInline
+package struct InvocationMetadata: Hashable, Sendable {
+    @usableFromInline
     package let requestID: String
+    @usableFromInline
     package let deadlineInMillisSinceEpoch: Int64
+    @usableFromInline
     package let invokedFunctionARN: String
+    @usableFromInline
     package let traceID: String
+    @usableFromInline
     package let clientContext: String?
+    @usableFromInline
     package let cognitoIdentity: String?
 
     package init(headers: HTTPHeaders) throws(LambdaRuntimeError) {

--- a/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
@@ -45,6 +45,7 @@ extension Lambda {
     ///     - body: Code to run within the context of the mock server. Typically this would be a Lambda.run function call.
     ///
     /// - note: This API is designed strictly for local testing and is behind a DEBUG flag
+    @usableFromInline
     static func withLocalServer(
         invocationEndpoint: String? = nil,
         _ body: sending @escaping () async throws -> Void

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -30,6 +30,7 @@ import ucrt
 #endif
 
 public enum Lambda {
+    @inlinable
     package static func runLoop<RuntimeClient: LambdaRuntimeClientProtocol, Handler>(
         runtimeClient: RuntimeClient,
         handler: Handler,

--- a/Sources/AWSLambdaRuntime/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntime/LambdaContext.swift
@@ -88,7 +88,7 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         self.storage.logger
     }
 
-    init(
+    public init(
         requestID: String,
         traceID: String,
         invokedFunctionARN: String,

--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -29,7 +29,9 @@ public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: St
     // TODO: We want to change this to Mutex as soon as this doesn't crash the Swift compiler on Linux anymore
     @usableFromInline
     let handlerMutex: NIOLockedValueBox<Handler?>
+    @usableFromInline
     let logger: Logger
+    @usableFromInline
     let eventLoop: EventLoop
 
     public init(

--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -27,6 +27,7 @@ import Foundation
 // sadly crashes the compiler today.
 public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: StreamingLambdaHandler {
     // TODO: We want to change this to Mutex as soon as this doesn't crash the Swift compiler on Linux anymore
+    @usableFromInline
     let handlerMutex: NIOLockedValueBox<Handler?>
     let logger: Logger
     let eventLoop: EventLoop
@@ -48,6 +49,7 @@ public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: St
         self.logger.debug("LambdaRuntime initialized")
     }
 
+    @inlinable
     public func run() async throws {
         let handler = self.handlerMutex.withLockedValue { handler in
             let result = handler

--- a/Sources/AWSLambdaRuntime/LambdaRuntimeClientProtocol.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntimeClientProtocol.swift
@@ -14,6 +14,7 @@
 
 import NIOCore
 
+@usableFromInline
 package protocol LambdaRuntimeClientResponseStreamWriter: LambdaResponseStreamWriter {
     func write(_ buffer: ByteBuffer) async throws
     func finish() async throws
@@ -21,14 +22,18 @@ package protocol LambdaRuntimeClientResponseStreamWriter: LambdaResponseStreamWr
     func reportError(_ error: any Error) async throws
 }
 
+@usableFromInline
 package protocol LambdaRuntimeClientProtocol {
     associatedtype Writer: LambdaRuntimeClientResponseStreamWriter
 
     func nextInvocation() async throws -> (Invocation, Writer)
 }
 
-package struct Invocation {
+@usableFromInline
+package struct Invocation: Sendable {
+    @usableFromInline
     package var metadata: InvocationMetadata
+    @usableFromInline
     package var event: ByteBuffer
 
     package init(metadata: InvocationMetadata, event: ByteBuffer) {

--- a/Sources/AWSLambdaRuntime/LambdaRuntimeError.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntimeError.swift
@@ -12,8 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+@usableFromInline
 package struct LambdaRuntimeError: Error {
-    package enum Code {
+    @usableFromInline
+    package enum Code: Sendable {
         case closingRuntimeClient
 
         case connectionToControlPlaneLost
@@ -34,12 +36,15 @@ package struct LambdaRuntimeError: Error {
         case invalidPort
     }
 
+    @usableFromInline
     package init(code: Code, underlying: (any Error)? = nil) {
         self.code = code
         self.underlying = underlying
     }
 
+    @usableFromInline
     package var code: Code
+    @usableFromInline
     package var underlying: (any Error)?
 
 }

--- a/Sources/AWSLambdaRuntime/Utils.swift
+++ b/Sources/AWSLambdaRuntime/Utils.swift
@@ -59,6 +59,7 @@ enum Signal: Int32 {
 }
 
 extension DispatchWallTime {
+    @usableFromInline
     init(millisSinceEpoch: Int64) {
         let nanoSinceEpoch = UInt64(millisSinceEpoch) * 1_000_000
         let seconds = UInt64(nanoSinceEpoch / 1_000_000_000)


### PR DESCRIPTION
Allow the compiler to specialize more code by applying `@inlinable` to generic code.