### PR TITLE
Revert "[ci] : Remove deprecated options on unit-test action"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,21 +17,13 @@ jobs:
       format_check_container_image: "swiftlang/swift:nightly-6.1-jammy"
       yamllint_check_enabled: true
 
-  # https://github.com/apple/swift-nio/blob/main/.github/workflows/unit_tests.yml
   unit-tests:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_enabled: true
-      # this currently resolves to 6.1 nightly
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_next_enabled: true
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
-      # this currently resolves to 6.2.dev
-      # It crashes some of our tests https://github.com/swift-server/swift-aws-lambda-runtime/issues/509
-      linux_nightly_main_enabled: true
+      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-tests:


### PR DESCRIPTION
Reverts swift-server/swift-aws-lambda-runtime#510

I think the issue https://github.com/swift-server/swift-aws-lambda-runtime/issues/509 that caused this tests disabling has been resolved in Swift and would like to confirm here as well.