### PR TITLE
Add SendableMetatype conformance

### DIFF
--- a/Sources/AWSLambdaRuntime/LambdaHandlers.swift
+++ b/Sources/AWSLambdaRuntime/LambdaHandlers.swift
@@ -20,7 +20,7 @@ import NIOCore
 /// Background work can also be executed after returning the response. After closing the response stream by calling
 /// ``LambdaResponseStreamWriter/finish()`` or ``LambdaResponseStreamWriter/writeAndFinish(_:)``,
 /// the ``handle(_:responseWriter:context:)`` function is free to execute any background work.
-public protocol StreamingLambdaHandler {
+public protocol StreamingLambdaHandler: _Lambda_SendableMetatype {
     /// The handler function -- implement the business logic of the Lambda function here.
     /// - Parameters:
     ///   - event: The invocation's input data.

--- a/Sources/AWSLambdaRuntime/SendableMetatype.swift
+++ b/Sources/AWSLambdaRuntime/SendableMetatype.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+@_documentation(visibility: internal)
+public typealias _Lambda_SendableMetatype = SendableMetatype
+#else
+@_documentation(visibility: internal)
+public typealias _Lambda_SendableMetatype = Any
+#endif


### PR DESCRIPTION
Add SendableMetatype conformance to StreamingLambdaHandler

### Motivation:

Swift 6.2 introduced new protocol SendableMetatype for Types that are Sendable 

### Modifications:

Added `_Lambda_SendableMetatype` typealias for SendableMetatype in Swift 6.2

and 

```swift
public protocol StreamingLambdaHandler: _Lambda_SendableMetatype {
```

### Result:

No more compile warnings
