### PR TITLE
Add support for local server graceful shutdown

### DIFF
--- a/Sources/AWSLambdaRuntime/LambdaRuntime+ServiceLifecycle.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime+ServiceLifecycle.swift
@@ -15,5 +15,11 @@
 #if ServiceLifecycleSupport
 import ServiceLifecycle
 
-extension LambdaRuntime: Service {}
+extension LambdaRuntime: Service {
+    public func run() async throws {
+        try await cancelWhenGracefulShutdown {
+            try await self._run()
+        }
+    }
+}
 #endif

--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -51,8 +51,15 @@ public final class LambdaRuntime<Handler>: @unchecked Sendable where Handler: St
         self.logger.debug("LambdaRuntime initialized")
     }
 
+    #if !ServiceLifecycleSupport
     @inlinable
-    public func run() async throws {
+    internal func run() async throws {
+        try await _run()
+    }
+    #endif
+
+    @inlinable
+    internal func _run() async throws {
         let handler = self.handlerMutex.withLockedValue { handler in
             let result = handler
             handler = nil


### PR DESCRIPTION
- Add ServiceLifecycle version of `LambdaRuntime.run` that wraps internal `_run` call in `cancelOnGracefulShutdown`
- Add cancellation handlers for shutting down existing connections in Local lambda
- Added test for lambda graceful shutdown

### Motivation:

Ensure local lambda supports graceful shutdown
