### PR TITLE
[WIP] DO NOT MERGE - [core] Remove `@unchecked Sendable` from Lambda Runtime (depends on PR#508)

### DIFF
--- a/Examples/APIGateway+LambdaAuthorizer/Sources/AuthorizerLambda/main.swift
+++ b/Examples/APIGateway+LambdaAuthorizer/Sources/AuthorizerLambda/main.swift
@@ -22,7 +22,7 @@ import AWSLambdaRuntime
 // This code is shown for the example only and is not used in this demo.
 // This code doesn't perform any type of token validation. It should be used as a reference only.
 let policyAuthorizerHandler:
-    @Sendable (APIGatewayLambdaAuthorizerRequest, LambdaContext) async throws ->
+    (APIGatewayLambdaAuthorizerRequest, LambdaContext) async throws ->
         APIGatewayLambdaAuthorizerPolicyResponse = {
             (request: APIGatewayLambdaAuthorizerRequest, context: LambdaContext) in
 
@@ -51,7 +51,9 @@ let policyAuthorizerHandler:
                 ]
             )
         }
-// let runtime = LambdaRuntime(body: policyAuthorizerHandler)
+// let runtime = LambdaRuntime() { try await policyAuthorizerHandler($0, $1) }
+// start polling for new events.
+// try await runtime.run()
 
 //
 // This is an example of a simple authorizer that always authorizes the request.

--- a/Examples/APIGateway+LambdaAuthorizer/Sources/AuthorizerLambda/main.swift
+++ b/Examples/APIGateway+LambdaAuthorizer/Sources/AuthorizerLambda/main.swift
@@ -22,58 +22,57 @@ import AWSLambdaRuntime
 // This code is shown for the example only and is not used in this demo.
 // This code doesn't perform any type of token validation. It should be used as a reference only.
 let policyAuthorizerHandler:
-    (APIGatewayLambdaAuthorizerRequest, LambdaContext) async throws -> APIGatewayLambdaAuthorizerPolicyResponse = {
-        (request: APIGatewayLambdaAuthorizerRequest, context: LambdaContext) in
+    @Sendable (APIGatewayLambdaAuthorizerRequest, LambdaContext) async throws ->
+        APIGatewayLambdaAuthorizerPolicyResponse = {
+            (request: APIGatewayLambdaAuthorizerRequest, context: LambdaContext) in
 
-        context.logger.debug("+++ Policy Authorizer called +++")
+            context.logger.debug("+++ Policy Authorizer called +++")
 
-        // typically, this function will check the validity of the incoming token received in the request
+            // typically, this function will check the validity of the incoming token received in the request
 
-        // then it creates and returns a response
-        return APIGatewayLambdaAuthorizerPolicyResponse(
-            principalId: "John Appleseed",
+            // then it creates and returns a response
+            return APIGatewayLambdaAuthorizerPolicyResponse(
+                principalId: "John Appleseed",
 
-            // this policy allows the caller to invoke any API Gateway endpoint
-            policyDocument: .init(statement: [
-                .init(
-                    action: "execute-api:Invoke",
-                    effect: .allow,
-                    resource: "*"
-                )
+                // this policy allows the caller to invoke any API Gateway endpoint
+                policyDocument: .init(statement: [
+                    .init(
+                        action: "execute-api:Invoke",
+                        effect: .allow,
+                        resource: "*"
+                    )
 
-            ]),
+                ]),
 
-            // this is additional context we want to return to the caller
-            context: [
-                "abc1": "xyz1",
-                "abc2": "xyz2",
-            ]
-        )
-    }
+                // this is additional context we want to return to the caller
+                context: [
+                    "abc1": "xyz1",
+                    "abc2": "xyz2",
+                ]
+            )
+        }
+// let runtime = LambdaRuntime(body: policyAuthorizerHandler)
 
 //
 // This is an example of a simple authorizer that always authorizes the request.
 // A simple authorizer returns a yes/no decision and optional context key-value pairs
 //
 // This code doesn't perform any type of token validation. It should be used as a reference only.
-let simpleAuthorizerHandler:
-    (APIGatewayLambdaAuthorizerRequest, LambdaContext) async throws -> APIGatewayLambdaAuthorizerSimpleResponse = {
-        (_: APIGatewayLambdaAuthorizerRequest, context: LambdaContext) in
+let runtime = LambdaRuntime {
+    (_: APIGatewayLambdaAuthorizerRequest, context: LambdaContext) -> APIGatewayLambdaAuthorizerSimpleResponse in
 
-        context.logger.debug("+++ Simple Authorizer called +++")
+    context.logger.debug("+++ Simple Authorizer called +++")
 
-        // typically, this function will check the validity of the incoming token received in the request
+    // typically, this function will check the validity of the incoming token received in the request
 
-        return APIGatewayLambdaAuthorizerSimpleResponse(
-            // this is the authorization decision: yes or no
-            isAuthorized: true,
+    return APIGatewayLambdaAuthorizerSimpleResponse(
+        // this is the authorization decision: yes or no
+        isAuthorized: true,
 
-            // this is additional context we want to return to the caller
-            context: ["abc1": "xyz1"]
-        )
-    }
+        // this is additional context we want to return to the caller
+        context: ["abc1": "xyz1"]
+    )
+}
 
-// create the runtime and start polling for new events.
-// in this demo we use the simple authorizer handler
-let runtime = LambdaRuntime(body: simpleAuthorizerHandler)
+// start polling for new events.
 try await runtime.run()

--- a/Sources/AWSLambdaRuntime/FoundationSupport/Lambda+JSON.swift
+++ b/Sources/AWSLambdaRuntime/FoundationSupport/Lambda+JSON.swift
@@ -95,7 +95,7 @@ extension LambdaRuntime {
         decoder: JSONDecoder = JSONDecoder(),
         encoder: JSONEncoder = JSONEncoder(),
         logger: Logger = Logger(label: "LambdaRuntime"),
-        body: sending @escaping (Event, LambdaContext) async throws -> Output
+        body: @Sendable @escaping (Event, LambdaContext) async throws -> Output
     )
     where
         Handler == LambdaCodableAdapter<
@@ -122,7 +122,7 @@ extension LambdaRuntime {
     public convenience init<Event: Decodable>(
         decoder: JSONDecoder = JSONDecoder(),
         logger: Logger = Logger(label: "LambdaRuntime"),
-        body: sending @escaping (Event, LambdaContext) async throws -> Void
+        body: @Sendable @escaping (Event, LambdaContext) async throws -> Void
     )
     where
         Handler == LambdaCodableAdapter<


### PR DESCRIPTION
This PR depends on https://github.com/swift-server/swift-aws-lambda-runtime/pull/508

When removing the `NIOLockedBox`, we wanted to remove the last `@unchecked Sendable`  in the code.

### Motivation:

There is no good reason to bypass compiler verifications with `@unchecked Sendable` in this scenario. We would like to bring the extra verifications' benefit to the user of the library.

### Modifications:

Lambda handlers and all depending structs and functions are tagged @Sendable

### Result:

This adds a requirement on user defined handlers (the public API of this library).
Code like 

```
let handler:
    (Event, LambdaContext) async throws -> Response = {
        (request: Event, context: LambdaContext) in
    ...
    return Response() 
}
let runtime = LambdaRuntime(body: handler) 
try await runtime().run() 
```

is no longer accepted.  The `handler` must marked `@Sendable` 

```
let handler:
    @Sendable (Event, LambdaContext) async throws -> Response = {
        (request: Event, context: LambdaContext) in
    ...
    return Response() 
}
```

Fortunately, thanks to the compiler type inference, this does not affect handlers passed as a closure, such as 

```
let runtime = LambdaRuntime {
    (event: HelloRequest, context: LambdaContext) in

    HelloResponse(
        greetings: "Hello \(event.name). You look \(event.age > 30 ? "younger" : "older") than your age."
    )
}
```

As we expect this is the preferred way to write a handler, we think the change in the public API is acceptable. Only more advanced users will have to explicitly add the `@Sendable` conformance to their standalone handler functions.


