### PR TITLE
[test] Add a test for cancellable

### DIFF
--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -82,7 +82,7 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
         // The handler can be non-sendable, we want to ensure we only ever have one copy of it
         let handler = try? self.handlerStorage.get()
         guard let handler else {
-            throw LambdaRuntimeError(code: .runtimeCanOnlyBeStartedOnce)
+            throw LambdaRuntimeError(code: .handlerCanOnlyBeGetOnce)
         }
 
         // are we running inside an AWS Lambda runtime environment ?

--- a/Sources/AWSLambdaRuntime/LambdaRuntimeError.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntimeError.swift
@@ -34,6 +34,7 @@ package struct LambdaRuntimeError: Error {
 
         case missingLambdaRuntimeAPIEnvironmentVariable
         case runtimeCanOnlyBeStartedOnce
+        case handlerCanOnlyBeGetOnce
         case invalidPort
     }
 

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntime+ServiceLifeCycle.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntime+ServiceLifeCycle.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 #if ServiceLifecycleSupport
 @testable import AWSLambdaRuntime
 import ServiceLifecycle

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntime+ServiceLifeCycle.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntime+ServiceLifeCycle.swift
@@ -1,0 +1,32 @@
+#if ServiceLifecycleSupport
+@testable import AWSLambdaRuntime
+import ServiceLifecycle
+import Testing
+import Logging
+
+@Suite
+struct LambdaRuntimeServiceLifecycleTests {
+    @Test
+    func testLambdaRuntimeGracefulShutdown() async throws {
+        let runtime = LambdaRuntime {
+            (event: String, context: LambdaContext) in
+            "Hello \(event)"
+        }
+
+        let serviceGroup = ServiceGroup(
+            services: [runtime],
+            gracefulShutdownSignals: [.sigterm, .sigint],
+            logger: Logger(label: "TestLambdaRuntimeGracefulShutdown")
+        )
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            // wait a small amount to ensure we are waiting for continuation
+            try await Task.sleep(for: .milliseconds(100))
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+}
+#endif

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTests.swift
@@ -15,7 +15,6 @@
 import Logging
 import NIOCore
 import NIOPosix
-import ServiceLifecycle
 import Testing
 
 import struct Foundation.UUID
@@ -140,28 +139,4 @@ struct LambdaRuntimeClientTests {
             }
         }
     }
-    #if ServiceLifecycleSupport
-    @Test
-    func testLambdaRuntimeGracefulShutdown() async throws {
-        let runtime = LambdaRuntime {
-            (event: String, context: LambdaContext) in
-            "Hello \(event)"
-        }
-
-        let serviceGroup = ServiceGroup(
-            services: [runtime],
-            gracefulShutdownSignals: [.sigterm, .sigint],
-            logger: Logger(label: "TestLambdaRuntimeGracefulShutdown")
-        )
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await serviceGroup.run()
-            }
-            // wait a small amount to ensure we are waiting for continuation
-            try await Task.sleep(for: .milliseconds(100))
-
-            await serviceGroup.triggerGracefulShutdown()
-        }
-    }
-    #endif
 }

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTests.swift
@@ -89,7 +89,7 @@ struct LambdaRuntimeClientTests {
     }
 
     @Test
-    func testCancellation() async throws {
+    func testRuntimeClientCancellation() async throws {
         struct HappyBehavior: LambdaServerBehavior {
             let requestId = UUID().uuidString
             let event = "hello"

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
@@ -50,7 +50,7 @@ struct LambdaRuntimeTests {
             }
 
             // wait a small amount to ensure runtime1 task is started
-            try await Task.sleep(for: .seconds(0.5))
+            try await Task.sleep(for: .seconds(1))
 
             // Running the second runtime should trigger LambdaRuntimeError
             await #expect(throws: LambdaRuntimeError.self) {
@@ -62,7 +62,7 @@ struct LambdaRuntimeTests {
         }
 
         // wait a small amount to ensure everything is cancelled and cleanup
-        try await Task.sleep(for: .seconds(0.5))
+        try await Task.sleep(for: .seconds(1))
 
         // Running the second runtime should work now
         try await withThrowingTaskGroup(of: Void.self) { taskGroup in

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
@@ -62,13 +62,8 @@ struct LambdaRuntimeTests {
                 try await taskGroup.next()
             }
 
-            // cancel the other task
+            // cancel the group to end the test 
             taskGroup.cancelAll()
-
-            // get the second result (should throw a ChannelError)
-            try await #require(throws: ChannelError.self) {
-                try await taskGroup.next()
-            }
 
         }
 

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
@@ -61,6 +61,9 @@ struct LambdaRuntimeTests {
             taskGroup.cancelAll()
         }
 
+        // wait a small amount to ensure everything is cancelled and cleanup
+        try await Task.sleep(for: .seconds(0.5))
+
         // Running the second runtime should work now
         try await withThrowingTaskGroup(of: Void.self) { taskGroup in
             taskGroup.addTask {

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
@@ -50,7 +50,8 @@ struct LambdaRuntimeTests {
             }
 
             // wait a small amount to ensure runtime1 task is started
-            try await Task.sleep(for: .seconds(1))
+            // on GH Actions, it might take a bit longer to start the runtime
+            try await Task.sleep(for: .seconds(2))
 
             // Running the second runtime should trigger LambdaRuntimeError
             await #expect(throws: LambdaRuntimeError.self) {

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
@@ -54,8 +54,11 @@ struct LambdaRuntimeTests {
             try await Task.sleep(for: .seconds(2))
 
             // Running the second runtime should trigger LambdaRuntimeError
-            await #expect(throws: LambdaRuntimeError.self) {
-                try await runtime2.run()
+            // start the first runtime
+            taskGroup.addTask {
+                await #expect(throws: LambdaRuntimeError.self) {
+                    try await runtime2.run()
+                }
             }
 
             // cancel runtime 1 / task 1

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
@@ -57,21 +57,19 @@ struct LambdaRuntimeTests {
                 try await runtime2.run()
             }
 
-            // get the first result (should be a LambdaRuntimeError)
-            let error1 = try await #require(throws: (any Error).self) {
+            // get the first result (should throw a LambdaRuntimeError)
+            try await #require(throws: LambdaRuntimeError.self) {
                 try await taskGroup.next()
             }
 
             // cancel the other task
             taskGroup.cancelAll()
 
-            // get the second result (should be a ChannelError)
-            let error2 = try await #require(throws: (any Error).self) {
+            // get the second result (should throw a ChannelError)
+            try await #require(throws: ChannelError.self) {
                 try await taskGroup.next()
             }
 
-            #expect(error1 is LambdaRuntimeError, "First runtime should throw LambdaRuntimeError")
-            #expect(error2 is ChannelError, "Second runtime should throw ChannelError")
         }
 
         // wait a small amount to ensure everything is cancelled and cleanup

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeTests.swift
@@ -62,26 +62,9 @@ struct LambdaRuntimeTests {
                 try await taskGroup.next()
             }
 
-            // cancel the group to end the test 
+            // cancel the group to end the test
             taskGroup.cancelAll()
 
-        }
-
-        // wait a small amount to ensure everything is cancelled and cleanup
-        try await Task.sleep(for: .seconds(0.5))
-
-        // Running the second runtime should work now
-        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
-            taskGroup.addTask {
-                // ChannelError will be thrown when we cancel the task group
-                await #expect(throws: ChannelError.self) {
-                    try await runtime2.run()
-                }
-            }
-
-            // Set timeout and cancel the runtime 2
-            try await Task.sleep(for: .seconds(1))
-            taskGroup.cancelAll()
         }
     }
     @Test("run() must be cancellable")

--- a/Tests/AWSLambdaRuntimeTests/PoolTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/PoolTests.swift
@@ -37,7 +37,7 @@ struct PoolTests {
     }
 
     @Test
-    func testCancellation() async throws {
+    func testPoolCancellation() async throws {
         let pool = LambdaHTTPServer.Pool<String>()
 
         // Create a task that will be cancelled


### PR DESCRIPTION
- Add a test on `LambdaRuntime` for cancellable.
- Move the service life cycle test to its own file