### PR TITLE
[core] Add support for streaming function to the local server

### DIFF
--- a/Examples/Streaming/README.md
+++ b/Examples/Streaming/README.md
@@ -34,6 +34,20 @@ swift package archive --allow-network-connections docker
 If there is no error, there is a ZIP file ready to deploy. 
 The ZIP file is located at `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingNumbers/StreamingNumbers.zip`
 
+## Test locally
+
+You can test the function locally before deploying:
+
+```bash
+swift run 
+
+# In another terminal, test with curl:
+curl -v \
+  --header "Content-Type: application/json" \
+  --data '"this is not used"' \
+  http://127.0.0.1:7000/invoke
+```
+
 ## Deploy with the AWS CLI
 
 Here is how to deploy using the `aws` command line.

--- a/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
@@ -440,7 +440,7 @@ internal struct LambdaHTTPServer {
                 LocalServerResponse(
                     id: requestId,
                     status: .ok,
-                    headers: HTTPHeaders([("Content-Type", "application/json")]),
+                    headers: HTTPHeaders(), // the local server has no mecanism to collect headers set by the lambda function
                     body: body,
                     final: true
                 )

--- a/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
@@ -274,7 +274,7 @@ internal struct LambdaHTTPServer {
 
                         case .end:
                             precondition(requestHead != nil, "Received .end without .head")
-                            
+
                             // process the buffered response for non streaming requests
                             if !self.isStreamingResponse(requestHead) {
                                 // process the request and send the response
@@ -288,7 +288,7 @@ internal struct LambdaHTTPServer {
                                 await self.responsePool.push(
                                     LocalServerResponse(id: requestId, final: true)
                                 )
-                            
+
                             }
 
                             requestHead = nil
@@ -311,16 +311,15 @@ internal struct LambdaHTTPServer {
     /// This function checks if the request is a streaming response request
     /// verb = POST, uri = :requestID/response, HTTP Header contains "Transfer-Encoding: chunked"
     private func isStreamingResponse(_ requestHead: HTTPRequestHead) -> Bool {
-        requestHead.method == .POST &&
-        requestHead.uri.hasSuffix(Consts.postResponseURLSuffix) &&
-        requestHead.headers.contains(name: "Transfer-Encoding") &&
-        requestHead.headers["Transfer-Encoding"].contains("chunked")
+        requestHead.method == .POST && requestHead.uri.hasSuffix(Consts.postResponseURLSuffix)
+            && requestHead.headers.contains(name: "Transfer-Encoding")
+            && requestHead.headers["Transfer-Encoding"].contains("chunked")
     }
 
     /// This function pareses and returns the requestId or nil if the request is malformed
     private func getRequestId(from head: HTTPRequestHead) -> String? {
-            let parts = head.uri.split(separator: "/")
-            return parts.count > 2 ? String(parts[parts.count - 2]) : nil  
+        let parts = head.uri.split(separator: "/")
+        return parts.count > 2 ? String(parts[parts.count - 2]) : nil
     }
     /// This function process the URI request sent by the client and by the Lambda function
     ///
@@ -378,7 +377,7 @@ internal struct LambdaHTTPServer {
                     try await self.sendResponse(response, outbound: outbound, logger: logger)
                     if response.final == true {
                         logger.trace("/invoke returning")
-                        return // if the response is final, we can return and close the connection
+                        return  // if the response is final, we can return and close the connection
                     }
                 } else {
                     logger.error(
@@ -497,7 +496,7 @@ internal struct LambdaHTTPServer {
         if response.final {
             logger.trace("Sending end")
             try await outbound.write(HTTPServerResponsePart.end(nil))
-        } 
+        }
     }
 
     /// A shared data structure to store the current invocation or response requests and the continuation objects.
@@ -585,7 +584,13 @@ internal struct LambdaHTTPServer {
         let headers: HTTPHeaders?
         let body: ByteBuffer?
         let final: Bool
-        init(id: String? = nil, status: HTTPResponseStatus? = nil, headers: HTTPHeaders? = nil, body: ByteBuffer? = nil, final: Bool = false) {
+        init(
+            id: String? = nil,
+            status: HTTPResponseStatus? = nil,
+            headers: HTTPHeaders? = nil,
+            body: ByteBuffer? = nil,
+            final: Bool = false
+        ) {
             self.requestId = id
             self.status = status
             self.headers = headers
@@ -604,14 +609,20 @@ internal struct LambdaHTTPServer {
             let headers = HTTPHeaders([
                 (AmazonHeaders.requestID, self.requestId),
                 (
-                AmazonHeaders.invokedFunctionARN,
-                "arn:aws:lambda:us-east-1:\(Int16.random(in: Int16.min ... Int16.max)):function:custom-runtime"
+                    AmazonHeaders.invokedFunctionARN,
+                    "arn:aws:lambda:us-east-1:\(Int16.random(in: Int16.min ... Int16.max)):function:custom-runtime"
                 ),
                 (AmazonHeaders.traceID, "Root=\(AmazonHeaders.generateXRayTraceID());Sampled=1"),
                 (AmazonHeaders.deadline, "\(DispatchWallTime.distantFuture.millisSinceEpoch)"),
             ])
 
-            return LocalServerResponse(id: self.requestId, status: .accepted, headers: headers, body: self.request, final: true)
+            return LocalServerResponse(
+                id: self.requestId,
+                status: .accepted,
+                headers: headers,
+                body: self.request,
+                final: true
+            )
         }
     }
 }

--- a/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
@@ -440,7 +440,8 @@ internal struct LambdaHTTPServer {
                 LocalServerResponse(
                     id: requestId,
                     status: .ok,
-                    headers: HTTPHeaders(), // the local server has no mecanism to collect headers set by the lambda function
+                    // the local server has no mecanism to collect headers set by the lambda function
+                    headers: HTTPHeaders(),
                     body: body,
                     final: true
                 )

--- a/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+LocalServer.swift
@@ -243,22 +243,36 @@ internal struct LambdaHTTPServer {
                             requestHead = head
 
                         case .body(let body):
-                            requestBody.setOrWriteImmutableBuffer(body)
+                            precondition(requestHead != nil, "Received .body without .head")
+
+                            // if this is a request from a Streaming Lambda Handler,
+                            // stream the response instead of buffering it
+                            if self.isStreamingResponse(requestHead) {
+                                // we are receiving a chunked body,
+                                // we can stream the response and not accumulate the chunks 
+                                print(String(buffer: body))
+                            } else {
+                                requestBody.setOrWriteImmutableBuffer(body)
+                            }
 
                         case .end:
                             precondition(requestHead != nil, "Received .end without .head")
-                            // process the request
-                            let response = try await self.processRequest(
-                                head: requestHead,
-                                body: requestBody,
-                                logger: logger
-                            )
-                            // send the responses
-                            try await self.sendResponse(
-                                response: response,
-                                outbound: outbound,
-                                logger: logger
-                            )
+                            
+                            // process the buffered response for non streaming requests
+                            if !self.isStreamingResponse(requestHead) {
+                                // process the complete request
+                                let response = try await self.processCompleteRequest(
+                                    head: requestHead,
+                                    body: requestBody,
+                                    logger: logger
+                                )
+                                // send the responses
+                                try await self.sendCompleteResponse(
+                                    response: response,
+                                    outbound: outbound,
+                                    logger: logger
+                                )
+                            }
 
                             requestHead = nil
                             requestBody = nil
@@ -273,6 +287,15 @@ internal struct LambdaHTTPServer {
         }
     }
 
+    /// This function checks if the request is a streaming response request
+    /// verb = POST, uri = :requestID/response, HTTP Header contains "Transfer-Encoding: chunked"
+    private func isStreamingResponse(_ requestHead: HTTPRequestHead) -> Bool {
+        requestHead.method == .POST &&
+        requestHead.uri.hasSuffix(Consts.postResponseURLSuffix) &&
+        requestHead.headers.contains(name: "Transfer-Encoding") &&
+        requestHead.headers["Transfer-Encoding"].contains("chunked")
+    }
+
     /// This function process the URI request sent by the client and by the Lambda function
     ///
     /// It enqueues the client invocation and iterate over the invocation queue when the Lambda function sends /next request
@@ -283,7 +306,7 @@ internal struct LambdaHTTPServer {
     ///   - body: the HTTP request body
     /// - Throws:
     /// - Returns: the response to send back to the client or the Lambda function
-    private func processRequest(
+    private func processCompleteRequest(
         head: HTTPRequestHead,
         body: ByteBuffer?,
         logger: Logger
@@ -406,7 +429,7 @@ internal struct LambdaHTTPServer {
         }
     }
 
-    private func sendResponse(
+    private func sendCompleteResponse(
         response: LocalServerResponse,
         outbound: NIOAsyncChannelOutboundWriter<HTTPServerResponsePart>,
         logger: Logger


### PR DESCRIPTION
The local server used for testing functions locally (`swift run`) now support streaming lambda functions

Fix https://github.com/swift-server/swift-aws-lambda-runtime/issues/528
