### PR TITLE
fix: [core] Hard code version number in user agent string (#98)

### DIFF
--- a/Sources/AWSLambdaRuntime/ControlPlaneRequestEncoder.swift
+++ b/Sources/AWSLambdaRuntime/ControlPlaneRequestEncoder.swift
@@ -93,7 +93,7 @@ struct ControlPlaneRequestEncoder: _EmittingChannelHandler {
 extension String {
     static let CRLF: String = "\r\n"
 
-    static let userAgent = "Swift-Lambda/Unknown"
+    static let userAgent = "Swift-Lambda/2.0"
     static let userAgentHeader: String = "user-agent: \(userAgent)\r\n"
     static let unhandledErrorHeader: String = "lambda-runtime-function-error-type: Unhandled\r\n"
 

--- a/Sources/AWSLambdaRuntime/ControlPlaneRequestEncoder.swift
+++ b/Sources/AWSLambdaRuntime/ControlPlaneRequestEncoder.swift
@@ -93,7 +93,7 @@ struct ControlPlaneRequestEncoder: _EmittingChannelHandler {
 extension String {
     static let CRLF: String = "\r\n"
 
-    static let userAgent = "Swift-Lambda/2.0"
+    static let userAgent = "Swift-Lambda/\(Version.current)"
     static let userAgentHeader: String = "user-agent: \(userAgent)\r\n"
     static let unhandledErrorHeader: String = "lambda-runtime-function-error-type: Unhandled\r\n"
 

--- a/Sources/AWSLambdaRuntime/Version.swift
+++ b/Sources/AWSLambdaRuntime/Version.swift
@@ -12,14 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-	/// The version of the AWS Lambda Runtime.
-	///
-	/// This is used in the User Agent header when making requests to the AWS Lambda data Plane.
-	///
-	/// - Note: This is a static property that returns the current version of the AWS Lambda Runtime.
-	///         It is used to ensure that the runtime can be identified by the AWS Lambda service.
-	///         As such, we mainly care about major version and minor version. Patch and pre-release versions are ignored.
+/// The version of the AWS Lambda Runtime.
+///
+/// This is used in the User Agent header when making requests to the AWS Lambda data Plane.
+///
+/// - Note: This is a static property that returns the current version of the AWS Lambda Runtime.
+///         It is used to ensure that the runtime can be identified by the AWS Lambda service.
+///         As such, we mainly care about major version and minor version. Patch and pre-release versions are ignored.
 package enum Version {
-		/// The current version of the AWS Lambda Runtime.
-		package static let current = "2.0"
+    /// The current version of the AWS Lambda Runtime.
+    package static let current = "2.0"
 }

--- a/Sources/AWSLambdaRuntime/Version.swift
+++ b/Sources/AWSLambdaRuntime/Version.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Library version of the AWS Lambda Runtime.
+/// This is used in the User Agent header when making requests to the AWS Lambda data Plane.
+package enum Version {
+		/// The current version of the AWS Lambda Runtime.
+		public static let current = "2.0"
+}

--- a/Sources/AWSLambdaRuntime/Version.swift
+++ b/Sources/AWSLambdaRuntime/Version.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Library version of the AWS Lambda Runtime.
-/// This is used in the User Agent header when making requests to the AWS Lambda data Plane.
+	/// The version of the AWS Lambda Runtime.
+	///
+	/// This is used in the User Agent header when making requests to the AWS Lambda data Plane.
+	///
+	/// - Note: This is a static property that returns the current version of the AWS Lambda Runtime.
+	///         It is used to ensure that the runtime can be identified by the AWS Lambda service.
+	///         As such, we mainly care about major version and minor version. Patch and pre-release versions are ignored.
 package enum Version {
 		/// The current version of the AWS Lambda Runtime.
-		public static let current = "2.0"
+		package static let current = "2.0"
 }


### PR DESCRIPTION
Add a hard coded version number to the user agent string, for an eventual identification by the Lambda service

### Motivation:

It's [an issue](https://github.com/swift-server/swift-aws-lambda-runtime/issues/108) that was open more than 5 years ago and was never addressed.  At the time, the consensus was to pickup a version number for the Package.swift file and the maintainer at the time decided to wait for Swift to implement this.
Five years later, and several major version of Swift later, this is still not available. I decided to move on and implement a less optimal solution. This can be replaced in the future if package version ever becomes part of Package.swift.

### Modifications:

Add a version enum to isolate the versioning in one place. I decided to keep it simple and not over engineering it with major, minor, patch and pre-release.  At the time, it's a simple string. This is all what we need for usage in the user agent string.

### Result:

User agent now identifies as `Swift-Lambda/2,0` instead of `Swift-Lambda/unknown`
