### PR TITLE
fix [core] trace level shows the first kb of the payload before being decoded

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -44,6 +44,21 @@ public enum Lambda {
                 let (invocation, writer) = try await runtimeClient.nextInvocation()
                 logger[metadataKey: "aws-request-id"] = "\(invocation.metadata.requestID)"
 
+                // when log level is trace or lower, print the first Kb of the payload
+                let bytes = invocation.event
+                var metadata: Logger.Metadata? = nil
+                if logger.logLevel <= .trace,
+                    let buffer = bytes.getSlice(at: 0, length: min(bytes.readableBytes, 1024))
+                {
+                        metadata = [
+                        "Event's first bytes": .string(String(buffer: buffer) + (bytes.readableBytes > 1024 ? "..." : ""))
+                    ]
+                }
+                logger.trace(
+                    "Sending invocation event to lambda handler",
+                    metadata: metadata
+                )
+
                 do {
                     try await handler.handle(
                         invocation.event,

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -46,6 +46,7 @@ public enum Lambda {
 
                 // when log level is trace or lower, print the first Kb of the payload
                 let bytes = invocation.event
+                let maxPayloadPreviewSize = 1024
                 var metadata: Logger.Metadata? = nil
                 if logger.logLevel <= .trace,
                     let buffer = bytes.getSlice(at: 0, length: min(bytes.readableBytes, maxPayloadPreviewSize))

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -48,10 +48,10 @@ public enum Lambda {
                 let bytes = invocation.event
                 var metadata: Logger.Metadata? = nil
                 if logger.logLevel <= .trace,
-                    let buffer = bytes.getSlice(at: 0, length: min(bytes.readableBytes, 1024))
+                    let buffer = bytes.getSlice(at: 0, length: min(bytes.readableBytes, maxPayloadPreviewSize))
                 {
                         metadata = [
-                        "Event's first bytes": .string(String(buffer: buffer) + (bytes.readableBytes > 1024 ? "..." : ""))
+                        "Event's first bytes": .string(String(buffer: buffer) + (bytes.readableBytes > maxPayloadPreviewSize ? "..." : ""))
                     ]
                 }
                 logger.trace(

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -51,8 +51,10 @@ public enum Lambda {
                 if logger.logLevel <= .trace,
                     let buffer = bytes.getSlice(at: 0, length: min(bytes.readableBytes, maxPayloadPreviewSize))
                 {
-                        metadata = [
-                        "Event's first bytes": .string(String(buffer: buffer) + (bytes.readableBytes > maxPayloadPreviewSize ? "..." : ""))
+                    metadata = [
+                        "Event's first bytes": .string(
+                            String(buffer: buffer) + (bytes.readableBytes > maxPayloadPreviewSize ? "..." : "")
+                        )
                     ]
                 }
                 logger.trace(


### PR DESCRIPTION
Add a log statement in the Lambda loop, before calling the user's handler to show the raw payload before any attempt to decode it.

This was available in Runtime v1 and is now ported to v2.
This fixes https://github.com/swift-server/swift-aws-lambda-runtime/issues/404

### Motivation:

This is useful when handling custom event and there is a Decoding error. It allows to see the exact payload received by the handler before any attempt to decode it.

### Modifications:

Add a log.trace statement with metatadata. Metadata are computed only when the log level is trace or below. 

### Result:

```
2025-07-21T08:58:33+0200 trace LambdaRuntime : Event's first bytes={"name": "me", "age": 50} aws-request-id=769127502334125 [AWSLambdaRuntime] sending invocation event to lambda handler
```
