### PR TITLE
Performance Test the invocation loop

### DIFF
--- a/Sources/MockServer/MockHTTPServer.swift
+++ b/Sources/MockServer/MockHTTPServer.swift
@@ -35,7 +35,7 @@ struct HttpServer {
     private let eventLoopGroup: MultiThreadedEventLoopGroup
     /// the mode. Are we mocking a server for a Lambda function that expects a String or a JSON document? (default: string)
     private let mode: Mode
-    /// the number of connections this server must accept before shutting down (default: 1)
+    /// the number of invocations this server must accept before shutting down (default: 1)
     private let maxInvocations: Int
     /// the logger (control verbosity with LOG_LEVEL environment variable)
     private let logger: Logger
@@ -91,10 +91,6 @@ struct HttpServer {
             ]
         )
 
-        // This counter is used to track the number of incoming connections.
-        // This mock servers accepts n TCP connection then shutdowns
-        let connectionCounter = SharedCounter(maxValue: self.maxInvocations)
-
         // We are handling each incoming connection in a separate child task. It is important
         // to use a discarding task group here which automatically discards finished child tasks.
         // A normal task group retains all child tasks and their outputs in memory until they are
@@ -105,21 +101,15 @@ struct HttpServer {
             try await channel.executeThenClose { inbound in
                 for try await connectionChannel in inbound {
 
-                    let counter = connectionCounter.current()
-                    logger.trace("Handling new connection", metadata: ["connectionNumber": "\(counter)"])
-
                     group.addTask {
-                        await self.handleConnection(channel: connectionChannel)
-                        logger.trace("Done handling connection", metadata: ["connectionNumber": "\(counter)"])
+                        await self.handleConnection(channel: connectionChannel, maxInvocations: self.maxInvocations)
+                        logger.trace("Done handling connection") //, metadata: ["connectionNumber": "\(counter)"])
                     }
 
-                    if connectionCounter.increment() {
-                        logger.info(
-                            "Maximum number of connections reached, shutting down after current connection",
-                            metadata: ["maxConnections": "\(self.maxInvocations)"]
-                        )
-                        break  // this causes the server to shutdown after handling the connection
-                    }
+                    // This mock server only accepts one connection
+                    // the Lambda Function Runtime will send multiple requests on that single connection
+                    // This Mock Server closes the connection when MAX_INVOCATION is reached
+                    break
                 }
             }
         }
@@ -131,17 +121,19 @@ struct HttpServer {
     /// It handles two requests: one for the next invocation and one for the response.
     /// when the maximum number of requests is reached, it closes the connection.
     private func handleConnection(
-        channel: NIOAsyncChannel<HTTPServerRequestPart, HTTPServerResponsePart>
+        channel: NIOAsyncChannel<HTTPServerRequestPart, HTTPServerResponsePart>,
+        maxInvocations: Int
     ) async {
 
         var requestHead: HTTPRequestHead!
         var requestBody: ByteBuffer?
 
-        // each Lambda invocation results in TWO HTTP requests (next and response)
-        let requestCount = SharedCounter(maxValue: 2)
+        // each Lambda invocation results in TWO HTTP requests (GET /next and POST /response)
+        let maxRequests = maxInvocations * 2
+        let requestCount = SharedCounter(maxValue: maxRequests)
 
         // Note that this method is non-throwing and we are catching any error.
-        // We do this since we don't want to tear down the whole server when a single connection
+        // We do this since we don't want to tear down the whole server when a single request
         // encounters an error.
         do {
             try await channel.executeThenClose { inbound, outbound in
@@ -178,7 +170,7 @@ struct HttpServer {
                         if requestCount.increment() {
                             logger.info(
                                 "Maximum number of requests reached, closing this connection",
-                                metadata: ["maxRequest": "2"]
+                                metadata: ["maxRequest": "\(maxRequests)"]
                             )
                             break  // this finishes handiling request on this connection
                         }


### PR DESCRIPTION
re-implement MAX_INVOCATIONS and fix shell script 
Fix https://github.com/swift-server/swift-aws-lambda-runtime/issues/377

### Motivation:

In v1, there was a script measuring the performance of the invocation loop.
Re-instate this script to allow user and develoeprs to measure the performance impact of their changes.

### Modifications:

I re-implemented MAX_INVOCATIONS, to avoid teh client looping against the Mock Server. But this time, MAX_INVOCATIONS is handled on the server, not on the client.

I slightly modified the script to work with v2 and the new MockServer.

### Result:

The script works.

This PR has a dependency on https://github.com/swift-server/swift-aws-lambda-runtime/issues/465
