### PR TITLE
fix: Fix deadline header with correct instant value (#551)

### DIFF
--- a/Sources/AWSLambdaRuntime/LambdaClock.swift
+++ b/Sources/AWSLambdaRuntime/LambdaClock.swift
@@ -62,7 +62,7 @@ public struct LambdaClock: Clock {
     /// ## Thread Safety
     ///
     /// `Instant` is a value type and is inherently thread-safe.
-    public struct Instant: InstantProtocol {
+    public struct Instant: InstantProtocol, CustomStringConvertible {
         /// The number of milliseconds since the Unix epoch.
         let instant: Int64
 
@@ -121,6 +121,11 @@ public struct LambdaClock: Clock {
         /// - Parameter milliseconds: The number of milliseconds since the Unix epoch.
         public init(millisecondsSinceEpoch milliseconds: Int64) {
             self.instant = milliseconds
+        }
+
+        /// Renders an Instant as an EPOCH value
+        public var description: String {
+            "\(self.instant)"
         }
     }
 

--- a/Tests/AWSLambdaRuntimeTests/LambdaClockTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaClockTests.swift
@@ -136,4 +136,12 @@ struct LambdaClockTests {
             "LambdaClock and Foundation Date should be within 10ms of each other, difference was \(difference)ms"
         )
     }
+    @Test("Instant renders as string with an epoch number")
+    func instantRendersAsStringWithEpochNumber() {
+        let clock = LambdaClock()
+        let instant = clock.now
+
+        let expectedString = "\(instant)"
+        #expect(expectedString.allSatisfy { $0.isNumber }, "String should only contain numbers")
+    }
 }


### PR DESCRIPTION
Instant's value now correctly prints as an EPOCH number

### Motivation:

A regression was introduced by https://github.com/swift-server/swift-aws-lambda-runtime/pull/540. The HTTP headers returned by `LocalServer` contained an invalid representation of the Lamba Deadline.

See https://github.com/swift-server/swift-aws-lambda-runtime/issues/551

### Modifications:

- Add `CustomStringConvertible` to `LambdaClock.Instant` to just print the `Int64` value 
- add a unit test 

### Result:

The runtime works correctly with the new `LambdaClock`