### PR TITLE
refactor the Swift Settings in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,17 @@
 
 import PackageDescription
 
+let defaultSwiftSettings: [SwiftSetting] =
+    [
+        .swiftLanguageMode(.v6),
+        // .enableExperimentalFeature(
+        //     "AvailabilityMacro=LambdaSwift 2.0:macOS 15.0"
+        // ),
+        //
+        // then, in code, use
+        // @available(LambdaSwift 2.0, *)
+    ]
+
 let package = Package(
     name: "swift-aws-lambda-runtime",
     platforms: [.macOS(.v15)],
@@ -43,7 +54,8 @@ let package = Package(
                     package: "swift-service-lifecycle",
                     condition: .when(traits: ["ServiceLifecycleSupport"])
                 ),
-            ]
+            ],
+            swiftSettings: defaultSwiftSettings
         ),
         .plugin(
             name: "AWSLambdaPackager",
@@ -67,8 +79,10 @@ let package = Package(
                 .byName(name: "AWSLambdaRuntime"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
-            ]
+            ],
+            swiftSettings: defaultSwiftSettings
         ),
+
         // for perf testing
         .executableTarget(
             name: "MockServer",
@@ -77,7 +91,8 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
-            ]
+            ],
+            swiftSettings: defaultSwiftSettings
         ),
     ]
 )

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -2,6 +2,13 @@
 
 import PackageDescription
 
+let defaultSwiftSettings: [SwiftSetting] = [
+    .define("FoundationJSONSupport"),
+    .define("ServiceLifecycleSupport"),
+    .define("LocalServerSupport"),
+    .swiftLanguageMode(.v6),
+]
+
 let package = Package(
     name: "swift-aws-lambda-runtime",
     platforms: [.macOS(.v15)],
@@ -28,11 +35,7 @@ let package = Package(
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
             ],
-            swiftSettings: [
-                .define("FoundationJSONSupport"),
-                .define("ServiceLifecycleSupport"),
-                .define("LocalServerSupport"),
-            ]
+            swiftSettings: defaultSwiftSettings
         ),
         .plugin(
             name: "AWSLambdaPackager",
@@ -57,11 +60,7 @@ let package = Package(
                 .product(name: "NIOTestUtils", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],
-            swiftSettings: [
-                .define("FoundationJSONSupport"),
-                .define("ServiceLifecycleSupport"),
-                .define("LocalServerSupport"),
-            ]
+            swiftSettings: defaultSwiftSettings
         ),
         // for perf testing
         .executableTarget(


### PR DESCRIPTION
DRY: define the swift settings once for all in `Package.swift`

### Motivation:

Avoid repeating ourself. Be sure the same settings are applied on all targets.

### Modifications:

Create a `var swiftSetting: [SwiftSettings]` and reuse it for all targets.

### Result:

More DRY
