### PR TITLE
Bump Amazon RDS version 19 PG 17

### DIFF
--- a/Examples/ServiceLifecycle+Postgres/template.yaml
+++ b/Examples/ServiceLifecycle+Postgres/template.yaml
@@ -120,7 +120,7 @@ Resources:
       DBInstanceIdentifier: servicelifecycle-postgres
       DBInstanceClass: db.t3.micro
       Engine: postgres
-      EngineVersion: '15.7'
+      EngineVersion: '17.6'
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref DatabaseSecret, ':SecretString:username}}']]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref DatabaseSecret, ':SecretString:password}}']]
       DBName: !Ref DBName


### PR DESCRIPTION
Update SwiftServiceLifeCycle example to use Postgres 17 (PG 15 is going to be deprecated on Amazon RDS)