### PR TITLE
[fix] The library must compile when no traits are enabled

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,7 +36,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'HummingbirdLambda', 'ResourcesPackaging', 'S3EventNotifier', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Streaming+Codable', 'ServiceLifecycle+Postgres', 'Testing', 'Tutorial' ]"
+      examples: "[ 'APIGateway', 'APIGateway+LambdaAuthorizer', 'BackgroundTasks', 'HelloJSON', 'HelloWorld', 'HelloWorldNoTraits', 'HummingbirdLambda', 'ResourcesPackaging', 'S3EventNotifier', 'S3_AWSSDK', 'S3_Soto', 'Streaming', 'Streaming+Codable', 'ServiceLifecycle+Postgres', 'Testing', 'Tutorial' ]"
       archive_plugin_examples: "[ 'HelloWorld', 'ResourcesPackaging' ]"
       archive_plugin_enabled: true
 

--- a/Examples/HelloWorldNoTraits/.gitignore
+++ b/Examples/HelloWorldNoTraits/.gitignore
@@ -1,0 +1,4 @@
+response.json
+samconfig.toml
+template.yaml
+Makefile

--- a/Examples/HelloWorldNoTraits/Package.swift
+++ b/Examples/HelloWorldNoTraits/Package.swift
@@ -1,0 +1,54 @@
+// swift-tools-version:6.1
+
+import PackageDescription
+
+// needed for CI to test the local version of the library
+import struct Foundation.URL
+
+let package = Package(
+    name: "swift-aws-lambda-runtime-example",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "MyLambda", targets: ["MyLambda"])
+    ],
+    dependencies: [
+        // during CI, the dependency on local version of swift-aws-lambda-runtime is added dynamically below
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "2.0.0-beta.3", traits: [])
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyLambda",
+            dependencies: [
+                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
+            ],
+            path: "Sources"
+        )
+    ]
+)
+
+if let localDepsPath = Context.environment["LAMBDA_USE_LOCAL_DEPS"],
+    localDepsPath != "",
+    let v = try? URL(fileURLWithPath: localDepsPath).resourceValues(forKeys: [.isDirectoryKey]),
+    v.isDirectory == true
+{
+    // when we use the local runtime as deps, let's remove the dependency added above
+    let indexToRemove = package.dependencies.firstIndex { dependency in
+        if case .sourceControl(
+            name: _,
+            location: "https://github.com/swift-server/swift-aws-lambda-runtime.git",
+            requirement: _
+        ) = dependency.kind {
+            return true
+        }
+        return false
+    }
+    if let indexToRemove {
+        package.dependencies.remove(at: indexToRemove)
+    }
+
+    // then we add the dependency on LAMBDA_USE_LOCAL_DEPS' path (typically ../..)
+    print("[INFO] Compiling against swift-aws-lambda-runtime located at \(localDepsPath)")
+    package.dependencies += [
+        .package(name: "swift-aws-lambda-runtime", path: localDepsPath, traits: [])
+    ]
+}

--- a/Examples/HelloWorldNoTraits/README.md
+++ b/Examples/HelloWorldNoTraits/README.md
@@ -1,0 +1,12 @@
+# Hello World, with no traits
+
+This is a simple example of an AWS Lambda function that takes a `String` as input parameter and returns a `String` as response.
+
+This function disables all the default traits: the support for JSON from Foundation, for Swift Service Lifecycle, and for the local server for testing.
+
+The main reasons of the existence of this example are 
+
+1. to show you how to disable traits when using the Lambda Runtime Library 
+2. to add an integration test to our continous integration pipeline to make sure the library compiles with no traits enabled.
+
+For more details about this example, refer to the example in `Examples/HelloWorld`.

--- a/Examples/HelloWorldNoTraits/Sources/main.swift
+++ b/Examples/HelloWorldNoTraits/Sources/main.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSLambdaRuntime
+import NIOCore
+
+let runtime = LambdaRuntime { event , response, context in
+    try await response.writeAndFinish(ByteBuffer(string: "Hello World!"))
+}
+
+try await runtime.run()

--- a/Sources/AWSLambdaRuntime/FoundationSupport/Lambda+JSON.swift
+++ b/Sources/AWSLambdaRuntime/FoundationSupport/Lambda+JSON.swift
@@ -84,7 +84,25 @@ extension LambdaCodableAdapter {
         )
     }
 }
-
+@available(LambdaSwift 2.0, *)
+extension LambdaResponseStreamWriter {
+    /// Writes the HTTP status code and headers to the response stream.
+    ///
+    /// This method serializes the status and headers as JSON and writes them to the stream,
+    /// followed by eight null bytes as a separator before the response body.
+    ///
+    /// - Parameters:
+    ///   - response: The status and headers response to write
+    ///   - encoder: The encoder to use for serializing the response, use JSONEncoder by default
+    /// - Throws: An error if JSON serialization or writing fails
+    public func writeStatusAndHeaders(
+        _ response: StreamingLambdaStatusAndHeadersResponse,
+        encoder: JSONEncoder = JSONEncoder()
+    ) async throws {
+        encoder.outputFormatting = .withoutEscapingSlashes
+        try await self.writeStatusAndHeaders(response, encoder: LambdaJSONOutputEncoder(encoder))
+    }
+}
 @available(LambdaSwift 2.0, *)
 extension LambdaRuntime {
     /// Initialize an instance with a `LambdaHandler` defined in the form of a closure **with a non-`Void` return type**.

--- a/Sources/AWSLambdaRuntime/LambdaResponseStreamWriter+Headers.swift
+++ b/Sources/AWSLambdaRuntime/LambdaResponseStreamWriter+Headers.swift
@@ -86,23 +86,3 @@ extension LambdaResponseStreamWriter {
         try await self.write(buffer, hasCustomHeaders: false)
     }
 }
-
-@available(LambdaSwift 2.0, *)
-extension LambdaResponseStreamWriter {
-    /// Writes the HTTP status code and headers to the response stream.
-    ///
-    /// This method serializes the status and headers as JSON and writes them to the stream,
-    /// followed by eight null bytes as a separator before the response body.
-    ///
-    /// - Parameters:
-    ///   - response: The status and headers response to write
-    ///   - encoder: The encoder to use for serializing the response, use JSONEncoder by default
-    /// - Throws: An error if JSON serialization or writing fails
-    public func writeStatusAndHeaders(
-        _ response: StreamingLambdaStatusAndHeadersResponse,
-        encoder: JSONEncoder = JSONEncoder()
-    ) async throws {
-        encoder.outputFormatting = .withoutEscapingSlashes
-        try await self.writeStatusAndHeaders(response, encoder: LambdaJSONOutputEncoder(encoder))
-    }
-}

--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -59,14 +59,12 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
     }
 
     #if !ServiceLifecycleSupport
-    @inlinable
-    internal func run() async throws {
+    public func run() async throws {
         try await _run()
     }
     #endif
 
     /// Make sure only one run() is called at a time
-    // @inlinable
     internal func _run() async throws {
 
         // we use an atomic global variable to ensure only one LambdaRuntime is running at the time


### PR DESCRIPTION
Make required changed to ensure the library compiles when no traits are enabled

+ add an example project that serves as test in the CI

### Motivation:

Recent changes introduced compilation errors when no traits are enabled.

### Modifications:

- LambdaResponseStreamWriter.writeStatusAndHeaders moved to the `FoundationSupport` directory where all classes and strict depending on `Foundation`, protected by `#if FoundationJSONSupport`
- `LambdaRuntime.run()` method when Service Life Cycle is disabled in now public (and therefore can not be `@inlinable` anymore)

Add an example that disables all traits.

Add this example to the CI 

### Result:

The Library now compiles when no default traits are enabled.
This is flagged `semver/major` because we change the public API `LambdaRuntime.run()`
