### PR TITLE
[examples] Use smaller containers in all examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Makefile
 .amazonq
 .kiro
 nodejs
+.ash

--- a/Examples/APIGateway+LambdaAuthorizer/template.yaml
+++ b/Examples/APIGateway+LambdaAuthorizer/template.yaml
@@ -35,7 +35,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       Environment:
@@ -60,7 +60,7 @@ Resources:
       Timeout: 29  # max 29 seconds for Lambda authorizers
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       Environment:

--- a/Examples/APIGateway/template.yaml
+++ b/Examples/APIGateway/template.yaml
@@ -11,7 +11,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       Environment:

--- a/Examples/CDK/infra/lib/lambda-api-project-stack.ts
+++ b/Examples/CDK/infra/lib/lambda-api-project-stack.ts
@@ -27,7 +27,7 @@ export class LambdaApiStack extends cdk.Stack {
       architecture: lambda.Architecture.ARM_64,
       handler: 'bootstrap',
       code: lambda.Code.fromAsset('../.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/APIGatewayLambda/APIGatewayLambda.zip'),
-      memorySize: 512,
+      memorySize: 128,
       timeout: cdk.Duration.seconds(30),
       environment: {
         LOG_LEVEL: 'debug',

--- a/Examples/HummingbirdLambda/template.yaml
+++ b/Examples/HummingbirdLambda/template.yaml
@@ -11,7 +11,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       Environment:

--- a/Examples/S3_AWSSDK/template.yaml
+++ b/Examples/S3_AWSSDK/template.yaml
@@ -11,7 +11,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       Environment:

--- a/Examples/S3_Soto/template.yaml
+++ b/Examples/S3_Soto/template.yaml
@@ -11,7 +11,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       Environment:

--- a/Examples/ServiceLifecycle+Postgres/INFRASTRUCTURE.md
+++ b/Examples/ServiceLifecycle+Postgres/INFRASTRUCTURE.md
@@ -56,7 +56,7 @@ The infrastructure consists of a secure VPC setup with private subnets only, con
 ### Service Lifecycle Lambda
 - **Runtime**: Custom runtime (provided.al2)
 - **Architecture**: ARM64
-- **Memory**: 512MB
+- **Memory**: 128MB
 - **Timeout**: 60 seconds
 - **Network**: Deployed in private subnets with access to database within VPC
 - **Environment Variables**:

--- a/Examples/ServiceLifecycle+Postgres/template.yaml
+++ b/Examples/ServiceLifecycle+Postgres/template.yaml
@@ -146,7 +146,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       VpcConfig:

--- a/Examples/Testing/template.yaml
+++ b/Examples/Testing/template.yaml
@@ -11,7 +11,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       Environment:

--- a/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
@@ -312,7 +312,7 @@ Resources:
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
       Runtime: provided.al2
-      MemorySize: 512
+      MemorySize: 128
       Architectures:
         - arm64
       # The events that will trigger this function  
@@ -489,7 +489,7 @@ export class LambdaApiStack extends cdk.Stack {
       architecture: lambda.Architecture.ARM_64,
       handler: 'bootstrap',
       code: lambda.Code.fromAsset('../.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/APIGatewayLambda/APIGatewayLambda.zip'),
-      memorySize: 512,
+      memorySize: 128,
       timeout: cdk.Duration.seconds(30),
       environment: {
         LOG_LEVEL: 'debug',


### PR DESCRIPTION
All the examples using SAM have a default Lambda runtime environment memory size of 512Mb.

Lambda functions run in a microVM defined by its memory size. The memory size influences the CPU power.
(see https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html) 

Increasing memory size increases runtime performance but also increase costs.

As most of our examples are very simple and small functions, 512Mb memory is not required. This PR reduces Lambda runtime execution environment to 128Mb to reduce AWS costs.

